### PR TITLE
fix: change logical id of docs checks to not be overwritten by marketing site [sc-00]

### DIFF
--- a/__checks__/site.check-group.ts
+++ b/__checks__/site.check-group.ts
@@ -1,6 +1,6 @@
 import { CheckGroup } from 'checkly/constructs'
 import { alertChannels } from './alertChannels'
-export const checklyhqComGroup = new CheckGroup('checklyhq-com-1', {
+export const checklyhqComGroup = new CheckGroup('checklyhq-docs-1', {
   name: 'checklyhq.com/docs',
   activated: true,
   muted: false,


### PR DESCRIPTION
## Affected Components
* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [ ] Docs
* [ ] Learn
* [x] Other

## Notes for the Reviewer

Update logical id for checks not to be overwritten by [marketing website checks](https://github.com/checkly/checkly-marketing-website/blob/main/__checks__/site.check-group.ts).

