### PR TITLE
fix: adds URL() to Slack example

### DIFF
--- a/site/content/docs/cli/constructs-reference.md
+++ b/site/content/docs/cli/constructs-reference.md
@@ -378,7 +378,7 @@ Sends a Slack message to an incoming Slack webhook address. You can specify the 
 import { SlackAlertChannel } from 'checkly/constructs'
 
 const slackChannel = new SlackAlertChannel('slack-channel-1', {
-  url: 'https://hooks.slack.com/services/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',
+  url: new URL('https://hooks.slack.com/services/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'),
   channel: '#ops'
 })
 ````


### PR DESCRIPTION
## Affected Components
* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [x] Docs
* [ ] Learn
* [ ] Other

## Pre-Requisites
* [ ] Code is linted (`npm run lint`)

## Notes for the Reviewer
- Slack uses the `URL` object for it's URL type, not a `string`