### PR TITLE
docs: Fixing incorrect `tag` param staging vs production

### DIFF
--- a/site/content/docs/cli/command-line-reference.md
+++ b/site/content/docs/cli/command-line-reference.md
@@ -130,7 +130,7 @@ npx checkly trigger --record --test-session-name="Adhoc test run" --location=eu-
 - `--reporter` or `-r`: A list of custom reporters for the test output. Options are: list|dot|ci|github.
 - `--tags` or `-t`: Filter the checks to be triggered using a comma separated list of tags. Checks will only be run if
 they contain all the specified tags. Multiple `--tags` flags can be passed, in which case checks will be run if they
-match any of the `--tag`s filters, i.e. `--tags production,webapp --tags production,backend` will run checks with tags
+match any of the `--tag`s filters, i.e. `--tags production,webapp --tags staging,backend` will run checks with tags
 (production AND webapp) OR (staging AND backend).
 - `--test-session-name` A name to use when storing results in Checkly with `--record`.
 - `--timeout`: A fallback timeout (in seconds) to wait for checks to complete. Default 240.


### PR DESCRIPTION
## Affected Components
* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [x] Docs
* [ ] Learn
* [ ] Other

Docs show example of using tags with CLI to trigger tests with (production AND webapp) OR (staging AND backend) tags, but the code example used included `production` rather than `staging`, minor typo fix 🙂