### PR TITLE
fix: adjust wording of `--no-schedule-on-deploy` flag

### DIFF
--- a/site/content/docs/cli/command-line-reference.md
+++ b/site/content/docs/cli/command-line-reference.md
@@ -81,7 +81,7 @@ npx checkly deploy
 - `--force` or `-f`: Skips the confirmation dialog when deploying. Handy in CI environments.
 - `--preview` or `-p`: Preview the differences between your actual configuration and your account.
 - `--output` or `-o`: Show applied differences after deploying.
-- `--no-schedule-on-deploy`: Do not schedule check runs when deploying.
+- `--no-schedule-on-deploy`: Do not run checks when deploying.
 
 When you deploy a project, you can attach Git specific information so changes to any resources are displayed in the
 Checkly web UI wit the correct commit, owner etc.


### PR DESCRIPTION
## Affected Components
* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [x] Docs
* [ ] Learn
* [ ] Other

## Pre-Requisites
* [ ] Code is linted (`npm run lint`)

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

As discussed in slack. :) A tiny wording change for the new CLI flag.

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->

## Screenshots
<!-- Screenshot of any visual changes -->
