### PR TITLE
chore: remove redirects from `vercel.json` because they're handled in…

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -31,45 +31,5 @@
         }
       ]
     }
-  ],
-  "redirects": [
-    {
-      "source": "/",
-      "has": [
-        {
-          "type": "host",
-          "value": "docs.checklyhq.com"
-        }
-      ],
-      "destination": "https://www.checklyhq.com/docs/"
-    },
-    {
-      "source": "/docs/api",
-      "destination": "https://developers.checklyhq.com"
-    },
-    {
-      "source": "/whats-new",
-      "destination": "https://www.checklyhq.com"
-    },
-    {
-      "source": "/learn",
-      "destination": "/learn/headless"
-    },
-    {
-      "source": "/docs/alerting/slack/",
-      "destination": "/docs/integrations/slack/"
-    },
-    {
-      "source": "/guides/e2e-monitoring/",
-      "destination": "/guides/end-to-end-monitoring/"
-    },
-    {
-      "source": "/docs/dashboards-v2/",
-      "destination": "/docs/dashboards/"
-    },
-    {
-      "source": "/docs/dashboards-v2/incidents/",
-      "destination": "/docs/dashboards/incidents/"
-    }
   ]
 }


### PR DESCRIPTION
… the marketing site

## Affected Components
* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [ ] Docs
* [ ] Learn
* [x] Other

## Pre-Requisites
* [ ] Code is linted (`npm run lint`)

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

Cleaning up redirects in the repo to handle them in the parent marketing repo. [Which is already merged](https://github.com/checkly/checkly-marketing-website/pull/87). 

That's the last one for today, promise! 🤞 

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->

## Screenshots
<!-- Screenshot of any visual changes -->
