### PR TITLE
fix: update some links to avoid redirects

### DIFF
--- a/site/content/guides/api-monitoring.md
+++ b/site/content/guides/api-monitoring.md
@@ -356,5 +356,5 @@ Teardown scripts run after the request has executed, bur right before the assert
 As we increase our monitoring coverage across our APIs, we can also increase the efficacy of our setup by:
 
 1. Importing existing [Swagger/OpenAPI specs](https://www.checklyhq.com/docs/api-checks/request-settings/#import-a-swagger--openapi-specification) or even [cURL commands](https://www.checklyhq.com/docs/api-checks/request-settings/#import-a-curl-request) using built-in functionality.
-2. [Defining our API checks as code](/guides/monitoring-as-code) to scale our setup while lowering maintenance needs.
-3. Combining our API checks with [E2E monitoring](/guides/end-to-end-monitoring) for any website or web app service whose API we might be monitoring.
+2. [Defining our API checks as code](/guides/monitoring-as-code/) to scale our setup while lowering maintenance needs.
+3. Combining our API checks with [E2E monitoring](/guides/end-to-end-monitoring/) for any website or web app service whose API we might be monitoring.

--- a/site/content/guides/monitoring-as-code.md
+++ b/site/content/guides/monitoring-as-code.md
@@ -476,7 +476,7 @@ You can find the complete setup described in this guide on our {{< newtabref  hr
 
 As our setup expands, we might want to deploy additional tools to make our lives easier. We could:
 
-1. Iterate over existing Playwright scripts and [create multiple checks while declaring only one resource](https://blog.checklyhq.com/scaling-puppeteer-playwright-on-checkly-with-terraform#iterating-through-scripts-for-shorter-config).
-2. [Group checks together](https://blog.checklyhq.com/scaling-puppeteer-playwright-on-checkly-with-terraform#grouping-checks-together) to better handle them in large numbers.
-3. [Use code snippets](https://blog.checklyhq.com/scaling-puppeteer-playwright-on-checkly-with-terraform#reducing-code-duplication-with-snippets) to avoid code duplication and reduce maintenance.
+1. Iterate over existing Playwright scripts and [create multiple checks while declaring only one resource](/blog/scaling-puppeteer-playwright-on-checkly-with-terraform/#iterating-through-scripts-for-shorter-config).
+2. [Group checks together](/blog/scaling-puppeteer-playwright-on-checkly-with-terraform/#grouping-checks-together) to better handle them in large numbers.
+3. [Use code snippets](/blog/scaling-puppeteer-playwright-on-checkly-with-terraform/#reducing-code-duplication-with-snippets) to avoid code duplication and reduce maintenance.
 4. Move your workflow to {{< newtabref  href="https://www.terraform.io/cloud" title="Terraform Cloud" >}} to easily collaborate with your team when managing your Monitoring-as-Code configuration.

--- a/site/content/guides/setup-scripts.md
+++ b/site/content/guides/setup-scripts.md
@@ -10,7 +10,7 @@ avatar: 'images/avatars/giovanni-rago.png'
 
 Checks run independently and on different schedules, possibly even following different retry logics when failures occur. It is therefore important not to create dependencies between them, which could introduce failures that do not depend on the target system's status, also known as "false failures" and "flakiness". Checkly prevents (or tries to prevent) this antipattern by having each check run fully isolated in its own sandbox.
 
-But then how do we run more complex API checks that might have prerequisites (e.g. auth tokens, test data) that themselves require an API call, or other similar preparation steps? That's what [setup scripts](/docs/api-checks/setup-teardown-scripts/#setup-scripts) are made for. They run right before the API check's main request and enable us to do any action that might be needed to make our check work according to industry [best practices](/learn/headless/valuable-tests/). 
+But then how do we run more complex API checks that might have prerequisites (e.g. auth tokens, test data) that themselves require an API call, or other similar preparation steps? That's what [setup scripts](/docs/api-checks/setup-teardown-scripts/#setup-scripts) are made for. They run right before the API check's main request and enable us to do any action that might be needed to make our check work according to industry [best practices](/learn/headless/valuable-tests/).
 
 ## Setup scripts
 
@@ -28,17 +28,17 @@ In many cases, we will need to pass data we have retrieved, modified or created 
 | `request.url`  | The request URL. Any separately defined query parameters are added at the end.  | String |
 | `request.body`  | The request body in string format.  | String  |
 | `request.headers`  | The request headers.  | Object |
-| `request.queryParameters`  | The request query parameters. | Object | 
+| `request.queryParameters`  | The request query parameters. | Object |
 
 This means we can, for example, set the `Authorization` header of the check's main request programmatically (maybe with a value we have just fetched in the same script) by setting `request.headers['Authorization'] = my_token`, or set the request body content with `request.body = { 'id': 123 }`.
 
-> Like for [Browser checks](/docs/browser-checks), which libraries and modules are available in setup and teardown scripts depends on which [Runtime](/docs/runtimes) you have chosen. You can find a list of exactly [which libraries are included](/docs/runtimes/specs) in which runtime.
+> Like for [Browser checks](/docs/browser-checks/), which libraries and modules are available in setup and teardown scripts depends on which [Runtime](/docs/runtimes/) you have chosen. You can find a list of exactly [which libraries are included](/docs/runtimes/specs/) in which runtime.
 
 ### Prepare test data
 
 A check that is self-contained is responsible for preparing (and cleaning up - more on that in [teardown scripts](/docs/api-checks/setup-teardown-scripts/#teardown-scripts)) all the test data it needs to properly test the target functionality. Let's take a look at an example.
 
-We [use Checkly to monitor Checkly](https://blog.checklyhq.com/how-we-monitor-checkly/)! That includes [our API](/docs/api), which exposes endpoints for CRUD operations on checks, groups, alert channels and other resources. One of the checks we run verifies that our `DELETE /v1/checks/{id}` works correctly. In order to verify that, we will need a check to actually delete. To keep things nice and clean, we can create a new check in the setup script, then retrieve its unique `id` and pass it to the main HTTP request so we can tell our API exactly which check to delete.
+We [use Checkly to monitor Checkly](https://blog.checklyhq.com/how-we-monitor-checkly/)! That includes [our API](/docs/api/), which exposes endpoints for CRUD operations on checks, groups, alert channels and other resources. One of the checks we run verifies that our `DELETE /v1/checks/{id}` works correctly. In order to verify that, we will need a check to actually delete. To keep things nice and clean, we can create a new check in the setup script, then retrieve its unique `id` and pass it to the main HTTP request so we can tell our API exactly which check to delete.
 
 First off, let's look at the basic HTTP request config inside our new API check. Note that this will be the request to delete the existing check, not the one to create the dummy check that will be deleted: that will be featured in our setup script, which will run before the request shown below.
 
@@ -146,7 +146,7 @@ Note that the check might still fail due to an issue with an endpoint other than
 
 There are several scenarios in which we might want to fetch test data from an external source. It might be out of convience, or because the data itself is changing often and we want to always grab the newest version, or maybe even because we want to make our check more dynamic to ensure our target system can handle different inputs.
 
-Our example will be about creating a new product for our webshop using its API. Specifically, we will 
+Our example will be about creating a new product for our webshop using its API. Specifically, we will
 
 1. Use our setup script to request the test data from an API generating random device information.
 2. Map that data field-by-field to match the schema of our target API.
@@ -221,6 +221,6 @@ const responseData = { // create the response body object
 request.body = JSON.stringify(responseData) // set request body to stringified response body object
 ```
 
-We built a fully encapsulated check that fetches dynamic (random, in this case) test data from an external API and repurposes it for one of our webshop's endpoints. 
+We built a fully encapsulated check that fetches dynamic (random, in this case) test data from an external API and repurposes it for one of our webshop's endpoints.
 
 > There is a huge variety of cases in which setup scripts can be used. Stay tuned for more examples over the coming weeks!

--- a/site/content/learn/_index.md
+++ b/site/content/learn/_index.md
@@ -1,0 +1,3 @@
+---
+sitemapExclude: true
+---


### PR DESCRIPTION
## Affected Components
* [x] Content & Marketing
* [ ] Pricing
* [ ] Test
* [x] Docs
* [ ] Learn
* [ ] Other

## Pre-Requisites
* [ ] Code is linted (`npm run lint`)

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

Weekly clean up of Search Console Errors. It's mainly adding trailing slashes to avoid us linking to redirects and aligning the sitemap with the actual content (exclude `/learn/` from sitemap).

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->

## Screenshots
<!-- Screenshot of any visual changes -->
