### PR TITLE
feat: update docs to reflect Private Location arm64 support

### DIFF
--- a/site/content/docs/browser-checks/_index.md
+++ b/site/content/docs/browser-checks/_index.md
@@ -229,6 +229,8 @@ If your application [has very specific requirements](https://playwright.dev/docs
 Checkly enables you to use `Google Chrome` with Playwright in runtime `2023.02`. 
 In order to use Google Chrome you need to explicitly opt-in by passing the `channel: 'chrome'` config.
 
+Google Chrome is not available on [Private Locations](/docs/private-locations) running on ARM64 and Apple silicon.
+
 {{< tabs "Google Chrome with Playwright test" >}}
 {{< tab "TypeScript" >}}
 ```ts

--- a/site/content/docs/private-locations/_index.md
+++ b/site/content/docs/private-locations/_index.md
@@ -79,7 +79,3 @@ new ApiCheck('hello-api-1', {
   }
 })
 ```
-
-## Known limitations
-
-- The Checkly Agent currently only supports x86/AMD64 architecture and not ARM64. This means Apple Mac M1 systems are not currently supported.

--- a/site/content/docs/private-locations/checkly-agent-configuration.md
+++ b/site/content/docs/private-locations/checkly-agent-configuration.md
@@ -61,7 +61,7 @@ CONTAINER ID   IMAGE                  COMMAND           CREATED       STATUS    
 
 ## Local Docker workflow
 
-You can easily install the Checkly Agent on your Macbook, Windows or Linux machine for local debugging using [Docker Desktop](https://docs.docker.com/desktop/). Currently the Agent is only available for AMD CPU architectures. ARM is not supported. The installation procedure is the same as described above.
+You can easily install the Checkly Agent on your Macbook, Windows or Linux machine for local debugging using [Docker Desktop](https://docs.docker.com/desktop/). The installation procedure is the same as described above.
 
 To resolve locally running webapps or APIs, e.g. some project running on `http://localhost:3000` you need to use the [internal
 Docker host](https://docs.docker.com/desktop/networking/) `http://host.docker.internal:3000` to bridge to your `localhost` address.


### PR DESCRIPTION
## Affected Components
* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [x] Docs
* [ ] Learn
* [ ] Other

## Pre-Requisites
* [ ] Code is linted (`npm run lint`)

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
The agent is being updated to support ARM64 and Apple silicon. This PR updates the docs accordingly.