### PR TITLE
docs: add 2fa login blog post to resource list

### DIFF
--- a/site/content/docs/browser-checks/login-scenarios.md
+++ b/site/content/docs/browser-checks/login-scenarios.md
@@ -164,3 +164,4 @@ Note the following:
 
 - [Microsoft Live Login](/learn/headless/e2e-microsoft-live-login/)
 - [Login with Google](/learn/headless/e2e-google-login/)
+- [How to Bypass TOTP-Based 2FA Login Flows](/blog/how-to-bypass-totp-based-2fa-login-flows-with-playwright/)


### PR DESCRIPTION
## Affected Components
* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [X] Docs
* [ ] Learn
* [ ] Other

## Pre-Requisites
* [ ] Code is linted (`npm run lint`)

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
This is probably a rather common problem, and  the excellent blog post by @stefanjudis provides a good solution. However it is not so easy to find. The `Login Scenarios` doc feels like a natural place for a user to look for a solution (I started there) and addition would also make it findable by people who search the docs for '2FA'.

## Screenshots
<!-- Screenshot of any visual changes -->
![Screenshot 2023-08-03 at 12-10-43 Login scenarios Checkly](https://github.com/checkly/docs.checklyhq.com/assets/42450444/6cfbece1-84dd-4190-9e3d-44b7f3529ccc)
