### PR TITLE
boyscout: update registry links

### DIFF
--- a/site/content/docs/terraform-provider/_index.md
+++ b/site/content/docs/terraform-provider/_index.md
@@ -13,7 +13,7 @@ aliases:
 The [Checkly Terraform provider](https://github.com/checkly/terraform-provider-checkly) enables you to declare your monitoring setup as code using [HashiCorp Terraform](https://www.terraform.io/). You can get started with it in a matter of minutes by following the steps shown below.
 
 If you prefer, you can also clone our [sample repository](https://github.com/checkly/checkly-terraform-getting-started) and play around with the resources on your own.
-For in-depth information on Terraform, please see HashiCorp's [official documentation](https://registry.terraform.io/providers/checkly/checkly/latest/docs).
+For in-depth information on Terraform, please see HashiCorp's [official documentation](https://developer.hashicorp.com/terraform/docs).
 
 {{<info>}}
 Looking for Monitoring as Code but don't want to use Terraform? Give our [CLI solution](/docs/cli/) a try.

--- a/site/content/docs/terraform-provider/alerting.md
+++ b/site/content/docs/terraform-provider/alerting.md
@@ -94,7 +94,7 @@ resource "checkly_alert_channel" "email_ac" {
 }
 ```
 
-Checkly supports a variety of alert channels, from email and SMS to Pagerduty and custom webhooks. For all available alert channels, see the corresponding [resource page](https://registry.terraform.io/providers/checkly/checkly/latest/docs/resources/checkly_alert_channel).
+Checkly supports a variety of alert channels, from email and SMS to Pagerduty and custom webhooks. For all available alert channels, see the corresponding [resource page](https://registry.terraform.io/providers/checkly/checkly/latest/docs/resources/alert_channel).
 
 ### Alert channel subscriptions
 

--- a/site/content/docs/terraform-provider/checks-groups.md
+++ b/site/content/docs/terraform-provider/checks-groups.md
@@ -194,4 +194,4 @@ resource "checkly_check" "get-books" {
 Locations and alert channel subscriptions defined at group level always trump the ones defined at check level. Double-check your config to make sure all checks are running from the intended regions and are set to alert on the correct channels.
 {{</info>}}
 
-You can see all the configuration options for groups, as well as more examples, on the official Terraform registry [documentation page](https://registry.terraform.io/providers/checkly/checkly/latest/docs/resources/checkly_check_group).
+You can see all the configuration options for groups, as well as more examples, on the official Terraform registry [documentation page](https://registry.terraform.io/providers/checkly/checkly/latest/docs/resources/check_group).

--- a/site/content/docs/terraform-provider/command-line-triggers.md
+++ b/site/content/docs/terraform-provider/command-line-triggers.md
@@ -28,4 +28,4 @@ output "test-trigger-group-url" {
 }
 ```
 
-You can see all the configuration options for [group triggers](https://registry.terraform.io/providers/checkly/checkly/latest/docs/resources/checkly_trigger_group), as well as more examples [check triggers](https://registry.terraform.io/providers/checkly/checkly/latest/docs/resources/checkly_trigger_check), on the official Terraform registry documentation page.
+You can see all the configuration options for [group triggers](https://registry.terraform.io/providers/checkly/checkly/latest/docs/resources/trigger_group), as well as more examples [check triggers](https://registry.terraform.io/providers/checkly/checkly/latest/docs/resources/trigger_check), on the official Terraform registry documentation page.

--- a/site/content/docs/terraform-provider/maintenance-windows.md
+++ b/site/content/docs/terraform-provider/maintenance-windows.md
@@ -20,4 +20,4 @@ resource "checkly_maintenance_windows" "maintenance-monthly" {
 }
 ```
 
-You can see all the configuration options for maintenance windows, as well as more examples, on the official Terraform registry [documentation page](https://registry.terraform.io/providers/checkly/checkly/latest/docs/resources/checkly_maintenance_windows).
+You can see all the configuration options for maintenance windows, as well as more examples, on the official Terraform registry [documentation page](https://registry.terraform.io/providers/checkly/checkly/latest/docs/resources/maintenance_windows).


### PR DESCRIPTION
## Affected Components
* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [x] Docs
* [ ] Learn
* [ ] Other

## Pre-Requisites
* [ ] Code is linted (`npm run lint`)

## Notes for the Reviewer
Just updated the links to the TF registry. Seems like the URLs changed with the latest provider release.
