### PR TITLE
docs: fix typo

### DIFF
--- a/site/content/docs/private-locations/running-on-kubernetes.md
+++ b/site/content/docs/private-locations/running-on-kubernetes.md
@@ -24,7 +24,7 @@ cd checkly-k8
 
 ## Helm chart
 
-Find the Helm chart in the `/helm-cart` directory. The Helm chart does two basic things:
+Find the Helm chart in the `/helm-chart` directory. The Helm chart does two basic things:
 - Creates a secret for the API key.
 - Spins up two pods running the Checkly Agent
 


### PR DESCRIPTION
There's a little typo in the docs. The directory name should be [helm-chart](https://github.com/checkly/checkly-k8s/tree/main/helm-chart).