### PR TITLE
feat: add Read More section on /guides [sc-18864]

### DIFF
--- a/site/content/guides/api-monitoring.md
+++ b/site/content/guides/api-monitoring.md
@@ -358,3 +358,13 @@ As we increase our monitoring coverage across our APIs, we can also increase the
 1. Importing existing [Swagger/OpenAPI specs](https://www.checklyhq.com/docs/api-checks/request-settings/#import-a-swagger--openapi-specification) or even [cURL commands](https://www.checklyhq.com/docs/api-checks/request-settings/#import-a-curl-request) using built-in functionality.
 2. [Defining our API checks as code](/guides/monitoring-as-code/) to scale our setup while lowering maintenance needs.
 3. Combining our API checks with [E2E monitoring](/guides/end-to-end-monitoring/) for any website or web app service whose API we might be monitoring.
+
+## Read More
+
+<div class="cards-list">
+{{< doc-card class="three-column-card" title="Checkly CLI" description="Understand monitoring as code (MaC) via our Checkly CLI." link="/guides/monitoring-as-code-cli/" >}}
+
+{{< doc-card class="three-column-card" title="End to end monitoring" description="Learn end-to-end monitoring with puppeteer and playwright to test key website flows." link="/guides/end-to-end-monitoring/" >}}
+
+{{< doc-card class="three-column-card" title="OpenAPI/Swagger Monitoring" description="OpenAPI and Swagger help users design and document APIs in a way that is readable from both humans and machines." link="/guides/openapi-swagger/" >}}
+</div>

--- a/site/content/guides/end-to-end-monitoring.md
+++ b/site/content/guides/end-to-end-monitoring.md
@@ -281,3 +281,13 @@ We learned things the hard way so you do not have to. When starting out, keep an
 * Long, unfocused tests: checking too much in a single test will make failures harder to debug. [Break it up instead](/learn/headless/valuable-tests/#keep-tests-focused), and enjoy the added parallelisation.
 
 * Messing up your own metrics, KPIs: remember, if you are not running against production, you want to make sure your E2E monitoring checks or tests are filtered out of your analytics. This is [rather easy to do](/docs/monitoring/allowlisting), with most headless browser tools normally identifying themselves as such from the start.
+
+## Read More
+
+<div class="cards-list">
+{{< doc-card class="three-column-card" title="Monitoring as code" description="Why should the way we manage monitoring be any different?" link="/guides/monitoring-as-code/" >}}
+
+{{< doc-card class="three-column-card" title="Checkly CLI" description="Understand monitoring as code (MaC) via our Checkly CLI." link="/guides/monitoring-as-code-cli/" >}}
+
+{{< doc-card class="three-column-card" title="Setup scripts for API monitoring" description="Setup scripts are a fundamental tool to tailor API checks to your own target endpoints." link="/guides/setup-scripts/" >}}
+</div>

--- a/site/content/guides/monitoring-as-code-cli.md
+++ b/site/content/guides/monitoring-as-code-cli.md
@@ -375,3 +375,13 @@ Expanding our initial setup from here is easy, please follow these links if you 
 1. [Why we built Monitoring as Code blog post](https://blog.checklyhq.com/why-we-built-a-developer-first-typescript-cli-for-monitoring-as-code/)
 2. [Deep-dive & live coding session](https://www.youtube.com/watch?v=IcaMW2opx2U)
 3. [Checkly CLI Docs](https://www.checklyhq.com/docs/cli/)
+
+## Read More
+
+<div class="cards-list">
+{{< doc-card class="three-column-card" title="Monitoring as code" description="Why should the way we manage monitoring be any different?" link="/guides/monitoring-as-code/" >}}
+
+{{< doc-card class="three-column-card" title="End to end monitoring" description="Learn end-to-end monitoring with puppeteer and playwright to test key website flows." link="/guides/end-to-end-monitoring/" >}}
+
+{{< doc-card class="three-column-card" title="Setup scripts for API monitoring" description="Setup scripts are a fundamental tool to tailor API checks to your own target endpoints." link="/guides/setup-scripts/" >}}
+</div>

--- a/site/content/guides/monitoring-as-code.md
+++ b/site/content/guides/monitoring-as-code.md
@@ -480,3 +480,13 @@ As our setup expands, we might want to deploy additional tools to make our lives
 2. [Group checks together](/blog/scaling-puppeteer-playwright-on-checkly-with-terraform/#grouping-checks-together) to better handle them in large numbers.
 3. [Use code snippets](/blog/scaling-puppeteer-playwright-on-checkly-with-terraform/#reducing-code-duplication-with-snippets) to avoid code duplication and reduce maintenance.
 4. Move your workflow to {{< newtabref  href="https://www.terraform.io/cloud" title="Terraform Cloud" >}} to easily collaborate with your team when managing your Monitoring-as-Code configuration.
+
+## Read More
+
+<div class="cards-list">
+{{< doc-card class="three-column-card" title="Checkly CLI" description="Understand monitoring as code (MaC) via our Checkly CLI." link="/guides/monitoring-as-code-cli/" >}}
+
+{{< doc-card class="three-column-card" title="End to end monitoring" description="Learn end-to-end monitoring with puppeteer and playwright to test key website flows." link="/guides/end-to-end-monitoring/" >}}
+
+{{< doc-card class="three-column-card" title="Setup scripts for API monitoring" description="Setup scripts are a fundamental tool to tailor API checks to your own target endpoints." link="/guides/setup-scripts/" >}}
+</div>

--- a/site/content/guides/openapi-swagger.md
+++ b/site/content/guides/openapi-swagger.md
@@ -233,3 +233,13 @@ As we look to increase our endpoint coverage across our APIs, we might want to e
 1. Learning more about [API monitoring](/guides/api-monitoring) basics and best practices.
 2. Defining our [API checks as code](/guides/monitoring-as-code) to scale our setup.
 3. Integrating our API monitoring with [E2E monitoring](/guides/end-to-end-monitoring) for our websites.
+
+## Read More
+
+<div class="cards-list">
+{{< doc-card class="three-column-card" title="Checkly CLI" description="Understand monitoring as code (MaC) via our Checkly CLI." link="/guides/monitoring-as-code-cli/" >}}
+
+{{< doc-card class="three-column-card" title="End to end monitoring" description="Learn end-to-end monitoring with puppeteer and playwright to test key website flows." link="/guides/end-to-end-monitoring/" >}}
+
+{{< doc-card class="three-column-card" title="Monitoring as code" description="Why should the way we manage monitoring be any different?" link="/guides/monitoring-as-code/" >}}
+</div>

--- a/site/content/guides/puppeteer-to-playwright.md
+++ b/site/content/guides/puppeteer-to-playwright.md
@@ -293,3 +293,13 @@ This reveals additional information about the check execution, including:
 > Aside from running a Playwright script, performance and error tracing also require the use of [Runtime](https://www.checklyhq.com/docs/runtimes/) `2021.06` or newer.
 
 > Note that cross-browser support is not available on Checkly - [our Browser checks run on Chromium](https://www.checklyhq.com/docs/browser-checks/) only.
+
+## Read More
+
+<div class="cards-list">
+{{< doc-card class="three-column-card" title="Checkly CLI" description="Understand monitoring as code (MaC) via our Checkly CLI." link="/guides/monitoring-as-code-cli/" >}}
+
+{{< doc-card class="three-column-card" title="End to end monitoring" description="Learn end-to-end monitoring with puppeteer and playwright to test key website flows." link="/guides/end-to-end-monitoring/" >}}
+
+{{< doc-card class="three-column-card" title="OpenAPI/Swagger Monitoring" description="OpenAPI and Swagger help users design and document APIs in a way that is readable from both humans and machines." link="/guides/openapi-swagger/" >}}
+</div>

--- a/site/content/guides/setup-scripts.md
+++ b/site/content/guides/setup-scripts.md
@@ -224,3 +224,13 @@ request.body = JSON.stringify(responseData) // set request body to stringified r
 We built a fully encapsulated check that fetches dynamic (random, in this case) test data from an external API and repurposes it for one of our webshop's endpoints.
 
 > There is a huge variety of cases in which setup scripts can be used. Stay tuned for more examples over the coming weeks!
+
+## Read More
+
+<div class="cards-list">
+{{< doc-card class="three-column-card" title="Checkly CLI" description="Understand monitoring as code (MaC) via our Checkly CLI." link="/guides/monitoring-as-code-cli/" >}}
+
+{{< doc-card class="three-column-card" title="End to end monitoring" description="Learn end-to-end monitoring with puppeteer and playwright to test key website flows." link="/guides/end-to-end-monitoring/" >}}
+
+{{< doc-card class="three-column-card" title="Monitoring as code" description="Why should the way we manage monitoring be any different?" link="/guides/monitoring-as-code/" >}}
+</div>

--- a/site/content/guides/the-programmable-monitoring-platform.md
+++ b/site/content/guides/the-programmable-monitoring-platform.md
@@ -213,3 +213,13 @@ The example above fetches an API definition from the network via a `getAllEndpoi
 Monitoring as code is more than writing config files. Read project code, iterate, or fetch data — the CLI's JavaScript and TypeScript execution enables you to tailor your monitoring setup to your existing application code (and not the other way around).
 
 What are your preferred monitoring as code patterns? [Join the Checkly community](/slack), let me know and I'm happy to include your favorite pattern in this guide.
+
+## Read More
+
+<div class="cards-list">
+{{< doc-card class="three-column-card" title="Checkly CLI" description="Understand monitoring as code (MaC) via our Checkly CLI." link="/guides/monitoring-as-code-cli/" >}}
+
+{{< doc-card class="three-column-card" title="End to end monitoring" description="Learn end-to-end monitoring with puppeteer and playwright to test key website flows." link="/guides/end-to-end-monitoring/" >}}
+
+{{< doc-card class="three-column-card" title="OpenAPI/Swagger Monitoring" description="OpenAPI and Swagger help users design and document APIs in a way that is readable from both humans and machines." link="/guides/openapi-swagger/" >}}
+</div>

--- a/src/scss/_guides.scss
+++ b/src/scss/_guides.scss
@@ -256,6 +256,50 @@
       }
     }
 	}
+	.cards-list {
+		display: flex;
+		justify-content: space-between;
+		flex-wrap: wrap;
+		width: 100%;
+		margin-top: 40px;
+
+		.text-wrap {
+			width: calc(100% - 58px);
+
+			h2 {
+				margin: 3px 0;
+				color: #0075ff;
+			}
+
+			h3 {
+				margin: 2px 0;
+				font-size: 20px;
+				line-height: 30px;
+			}
+
+			p {
+				font-size: 14px;
+				line-height: 20px;
+			}
+		}
+
+		.three-column-card {
+			width: calc((100% - 50px)/3);
+			display: flex;
+			background-color: #e7f2ff;
+			justify-content-space: space-between;
+			padding: 20px;
+			border-radius: 6px;
+
+			.text-wrap {
+				width: 100%;
+				h3 {
+					font-size: 16px;
+					line-height: 24px;
+				}
+			}
+		}
+	}
 	&-page {
     min-width: 20rem;
     flex-grow: 1;


### PR DESCRIPTION
## Affected Components
* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [X] Docs
* [ ] Learn
* [ ] Other

## Pre-Requisites
* [ ] Code is linted (`npm run lint`)

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->
Add Read More on /guides as we have on /docs + /learn. This implementation was approved by the SEO agency.

## Screenshots
<!-- Screenshot of any visual changes -->
<img width="1141" alt="image" src="https://github.com/checkly/docs.checklyhq.com/assets/47372639/4e3bc0c8-e5dc-441b-a2f5-94408deb9316">
