### PR TITLE
docs: document RetryStrategyBuilder.noRetries()

### DIFF
--- a/site/content/docs/cli/constructs-reference.md
+++ b/site/content/docs/cli/constructs-reference.md
@@ -715,6 +715,7 @@ new ApiCheck('retrying-check', {
 
 `RetryStrategyBuilder` supports the following helper methods:
 
+* `noRetries()`: No retries are performed.
 * `fixedStrategy(options)`: A fixed time between retries, e.g. 5s, 5s, 5s etc.
 * `linearStrategy(options)`: A linearly increasing time between retries, e.g. 5s, 10s, 15s, etc.
 * `exponentialStrategy(options)`: An exponentially increasing time between retries, e.g. 5s, 25s, 125s (2m and 5s) etc.


### PR DESCRIPTION
## Affected Components
* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [x] Docs
* [ ] Learn
* [ ] Other

## Pre-Requisites
* [ ] Code is linted (`npm run lint`)

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
The CLI now supports `RetryStrategyBuilder.noRetries()` to disable the default retry strategy (introduced in CLI 4.6.3 with https://github.com/checkly/checkly-cli/pull/944). 

I'm not sure there's a better way to rephrase the following sentence, since `noRetries()` doesn't take an `options` argument:
> For all of the methods above, the `options` argument can be used to customize the following properties:

