### PR TITLE
fix: add missing open graphs [sc-20405]

### DIFF
--- a/site/layouts/partials/head.html
+++ b/site/layouts/partials/head.html
@@ -10,9 +10,10 @@
   <link rel="stylesheet" href="/css/style.css" />
 
   <meta property="og:type" content="article" />
-  <meta property=“og:title” content="{{ if .IsHome }}{{ .Site.Title }}{{ else if .Params.metatags.title }}{{ .Params.metatags.title }}{{ else }}{{ .Title }} | Checkly{{ end }}" />
+  <meta property="og:title" content="{{ if .IsHome }}{{ .Site.Title }}{{ else if .Params.metatags.title }}{{ .Params.metatags.title }}{{ else }}{{ .Title }} | Checkly{{ end }}" />
   <meta property="og:description" content="{{ with .Description }}{{ . | markdownify }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . | markdownify}}{{ end }}{{ end }}{{ end }}" />
   <meta property="og:type" content="{{ if .IsPage }}article{{ else }}website{{ end }}" />
+  <meta property="og:url" content="{{ .Permalink }}" />
   {{ $template_name := .Scratch.Get "template_name"}}
   {{ $breadcrumb_text := .Scratch.Get "breadcrumb_text"}}
   {{ $subtitle_text := .Scratch.Get "subtitle_text"}}

--- a/site/layouts/welcome/list.html
+++ b/site/layouts/welcome/list.html
@@ -9,7 +9,7 @@
   <meta name="viewport" content="width=device-width" initial-scale="1" maximum-scale="1">
 
   <meta property="og:type" content="article">
-  <meta property="“og:title”" content="Build and Run Synthetics That Scale">
+  <meta property="og:title" content="Build and Run Synthetics That Scale">
   <meta property="og:description" content="Monitoring as code workflow for developers: programmable, fast, reliable.">
   <meta property="og:type" content="website">
 


### PR DESCRIPTION
## Affected Components
* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [ ] Docs
* [ ] Learn
* [ ] Other

## Pre-Requisites
* [ ] Code is linted (`npm run lint`)

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->
Some of our pages with a good amount of traffic on the learn section are missing one or more of the required Open Graph tags. Fix og:title and add og:url 
