### PR TITLE
Update limit to 2.9, use correct units GiB

### DIFF
--- a/site/content/docs/runtimes/specs.md
+++ b/site/content/docs/runtimes/specs.md
@@ -12,12 +12,12 @@ cli: true
 By default, all our runners have their timezone set to UTC, regardless of their location.
 
 ## Resource limitations
-Each Browser and Multistep check can use up to `3.6GB` of memory and `2 CPU` cores. 
+Each Browser and Multistep check can use up to `2.9 GiB` of memory and `2 CPU` cores. 
 This limit applies to all processes spawned by the check, including the browser, the test framework, and the test code itself.
 The limit is enforced by the runner and is not configurable. 
 
 > When the memory limit is exceeded, 
-the check will automatically fail with a relevant error message, for example: `Your check has reached the maximum memory usage of 3.6GB`.
+the check will automatically fail with a relevant error message, for example: `Your check has reached the maximum memory usage of 2.9 GiB`.
 
 ## Built-in Node.js modules
 


### PR DESCRIPTION
## Affected Components
* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [x] Docs
* [ ] Learn
* [ ] Other

## Pre-Requisites
* [ ] Code is linted (`npm run lint`)

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
* Update the specs according to our new EKS limits
* We are allocating 3000 MiB for browser check pods, and we gracefully fail the check run when it reaches 99% of that limit which is 2.9 GiB
* Use GiB because we are not selling USB sticks