### PR TITLE
this is a fix for the page metadata being used as display information…

### DIFF
--- a/site/content/guides/monitoring-as-code-cli.md
+++ b/site/content/guides/monitoring-as-code-cli.md
@@ -1,6 +1,10 @@
 ---
-title: Monitoring as code with the Checkly CLI
-description: >-
+title: What is End to End Monitoring? Overview with Examples
+displayTitle: Monitoring as code with the Checkly CLI
+metatags:
+  title: What is End to End Monitoring? Overview with Examples
+description: Discover how Monitoring as Code transforms cloud infrastructure management with a hands-on Checkly case study. Start optimizing your workflow today!
+displayDescription: >-
   The as code movement has been picking up steam over the last few years, offering a way for DevOps teams to transparently manage and scale cloud infrastructure, security and other ressources. Why should the way we manage monitoring be any different? In this article, we address this point and illustrate it with a practical example of monitoring as code (MaC) via our Checkly CLI.
 author: Hannes Lenke
 avatar: 'images/avatars/hannes-lenke.png'

--- a/site/content/learn/headless/_index.md
+++ b/site/content/learn/headless/_index.md
@@ -1,6 +1,8 @@
 ---
-Title: Learn Playwright & Puppeteer
-description: 
+title: Learn Playwright & Puppeteer Browser Automation Frameworks
+displayTitle: Learn Playwright & Puppeteer
+description: Learn more about Playwright & Puppeteer with Checkly. Explore how to automate your web with a reliable, programmable monitoring workflow.
+displayDescription: 
   Learn more about Playwright & Puppeteer with Checkly. Explore how to automate your web with a reliable, programmable monitoring workflow.
 metatags:
   title: Learn Playwright & Puppeteer - Browser Automation Frameworks

--- a/site/content/learn/headless/basics-navigation.md
+++ b/site/content/learn/headless/basics-navigation.md
@@ -1,5 +1,6 @@
 ---
-title: Navigation & waiting
+title: Navigation & Waiting Strategies in Puppeteer & Playwright
+displayTitle: Navigation & waiting
 metatags:
   title: Navigation & Waiting Strategies in Puppeteer & Playwright
 subTitle: How to ensure elements are ready for interaction

--- a/site/content/learn/headless/basics-selectors.md
+++ b/site/content/learn/headless/basics-selectors.md
@@ -1,7 +1,6 @@
 ---
-title: Working with selectors
-metatags:
-    title: UI Selectors - A Guide for Puppeteer & Playwright | Checkly
+title: UI Selectors - A Guide for Puppeteer & Playwright | Checkly
+displayTitle: Working with selectors
 description: 
   Learn to write solid scripts using Puppeteer, Playwright, and other UI selectors. Discover how to choose stable selectors and start enhancing your skills today.
 subTitle: Techniques and pointers

--- a/site/layouts/guides/list.html
+++ b/site/layouts/guides/list.html
@@ -8,8 +8,20 @@
   				<div class="guide-card">
   					<div>
 						<div class="guide-info">
-							<h2><a href="{{ .RelPermalink }}">{{ .Title }}</a></h2>
-							<p>{{ .Params.description }}</p>
+							<h2><a href="{{ .RelPermalink }}">          
+							{{ if .Params.displayTitle}}
+								{{.Params.displayTitle}}
+							  {{else}}
+								{{.Title}}
+							  {{end}}
+							</a></h2>
+							<p>
+								{{ if .Params.displayDescription}}
+									{{.Params.displayDescription}}
+								{{else}}
+									{{.Description}}
+								{{end}}
+							</p>
 						</div>
 						<div class="write-info">
 							<img src="{{ .Params.avatar | relURL }}" alt="{{ .Params.author }}"  width="24" height="24" />

--- a/site/layouts/guides/single.html
+++ b/site/layouts/guides/single.html
@@ -5,13 +5,25 @@
       	<div class="guides__label">
       		Checkly Guides
       	</div>
-      	<h1 class="guides__title">{{.Title}}</h1>
+      	<h1 class="guides__title">
+          {{ if .Params.displayTitle}}
+            {{.Params.displayTitle}}
+          {{else}}
+            {{.Title}}
+          {{end}}
+        </h1>
         <div class="guides-toc-mobile mb-5 pt-3">
           <div class="guides-toc-header mb-3 pt-3">On this page</div>
           {{ .Page.TableOfContents }}
         </div>
-      	{{ if .Description }}
-      	<p class="guides__description">{{.Description}}</p>
+      	{{ if or (.Description) (.Params.displayDescription) }}
+      	<p class="guides__description">
+          {{ if .Params.displayDescription}}
+            {{.Params.displayDescription}}
+          {{else}}
+            {{.Description}}
+          {{end}}
+        </p>
       	{{ end }}
         <span class="markdown">{{.Content}}</span>
       </div>

--- a/site/layouts/learn/list.html
+++ b/site/layouts/learn/list.html
@@ -8,7 +8,13 @@
           <img src="/images/icons/toc-icon.svg" alt="table of contents" width="14" height="12" /> Table of contents
         </div>
       </div>
-      <h1>{{ .Title }}</h1>
+      <h1>
+        {{ if .Params.displayTitle}}
+          {{.Params.displayTitle}}
+        {{else}}
+          {{.Title}}
+        {{end}}
+      </h1>
       <div class="learn-toc-mobile mb-5 pt-3">
         <div class="learn-toc-header mb-3 pt-3">On this page</div>
         {{ .Page.TableOfContents }}

--- a/site/layouts/learn/single.html
+++ b/site/layouts/learn/single.html
@@ -26,7 +26,12 @@
             {{ end }}
           {{ end }}
         </div>
-        <h1>{{ .Title }}</h1>
+        <h1>        
+        {{ if .Params.displayTitle}}
+          {{.Params.displayTitle}}
+        {{else}}
+          {{.Title}}
+        {{end}}</h1>
         <div class="learn-toc-mobile mb-5 pt-3">
           <div class="learn-toc-header mb-3 pt-3">On this page</div>
           {{ .Page.TableOfContents }}

--- a/site/layouts/partials/docs-title.html
+++ b/site/layouts/partials/docs-title.html
@@ -1,6 +1,8 @@
 {{ $title := "" }}
 
-{{ if .Title }}
+{{ if .Page.Params.displayTitle}}
+  {{ $title = .Page.Params.displayTitle}}
+{{ else if .Title }}
   {{ $title = .Title }}
 {{ else if and .IsSection .File }}
   {{ $sections := split (trim .File.Dir "/") "/" }}

--- a/site/layouts/partials/head.html
+++ b/site/layouts/partials/head.html
@@ -1,5 +1,13 @@
 <head>
-  <title>{{ if .IsHome }}{{ .Site.Title }}{{ else if .Params.head.title }}{{ .Params.head.title }}{{ else }}{{ .Title }} | Checkly {{ end }}</title>
+  <title>
+    {{$title := "Checkly Documentation"}}
+    {{ if .IsHome }}{{ $title = .Site.Title }}{{ else if .Params.head.title }}{{ $title =.Params.head.title }}{{ else }}{{ $title = .Title }}{{ end }}     
+    {{$titleLength := $title | len}}
+    {{if lt $titleLength 50}}
+    {{$title}} | Checkly
+    {{else}}
+    {{$title}}
+    {{end}}</title>
   <meta charset="utf-8" />
   <meta name="description" content="{{ with .Description }}{{ . | markdownify }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . | markdownify}}{{ end }}{{ end }}{{ end }}" />
   <meta name="viewport" content="width=device-width" initial-scale="1" maximum-scale="1" />


### PR DESCRIPTION
… in the guides, which prevented us from having an SEO-friendly title (and description) that was different from the display title (and description). I would not claim that this solve is particularly elegant, but it does work, and didn't require me to alter any guides not needing SEO updates.

Future updates should make the same change for /learn and /docs

## Affected Components
* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [x] Docs
* [ ] Learn
* [ ] Other


