### PR TITLE
docs: document CLI retries support

### DIFF
--- a/site/content/docs/cli/command-line-reference.md
+++ b/site/content/docs/cli/command-line-reference.md
@@ -57,8 +57,8 @@ between environments.
   they contain all the specified tags. Multiple `--tags` flags can be passed, in which case checks will be run if they
   match any of the `--tags` filters, i.e. `--tags production,webapp --tags staging,backend` will run checks with tags
   (production AND webapp) OR (staging AND backend).
-- `--retries`: How many times to retry a failing check run.
-- `--timeout`: A fallback timeout (in seconds) to wait for checks to complete.
+- `--retries`: How many times to retry a failing check run. 0 by default and maximum 3.
+- `--timeout`: A fallback timeout (in seconds) to wait for checks to complete. 600 seconds by default.
 - `--update-snapshots` or `-u`: Update the golden images / reference snapshots of your visual comparison and snapshot tests.
 - `--verbose` or `-v`: Always show the full logs of the checks.
 
@@ -135,8 +135,8 @@ they contain all the specified tags. Multiple `--tags` flags can be passed, in w
 match any of the `--tag`s filters, i.e. `--tags production,webapp --tags staging,backend` will run checks with tags
 (production AND webapp) OR (staging AND backend).
 - `--test-session-name` A name to use when storing results in Checkly with `--record`.
-- `--retries`: How many times to retry a failing check run.
-- `--timeout`: A fallback timeout (in seconds) to wait for checks to complete. Default 240.
+- `--retries`: How many times to retry a failing check run. 0 by default and maximum 3.
+- `--timeout`: A fallback timeout (in seconds) to wait for checks to complete. 600 seconds by default.
 - `--verbose` or `-v`: Always show the full logs of the checks.
 
 ## `npx checkly login`

--- a/site/content/docs/cli/command-line-reference.md
+++ b/site/content/docs/cli/command-line-reference.md
@@ -57,6 +57,7 @@ between environments.
   they contain all the specified tags. Multiple `--tags` flags can be passed, in which case checks will be run if they
   match any of the `--tags` filters, i.e. `--tags production,webapp --tags staging,backend` will run checks with tags
   (production AND webapp) OR (staging AND backend).
+- `--retries`: How many times to retry a failing check run.
 - `--timeout`: A fallback timeout (in seconds) to wait for checks to complete.
 - `--update-snapshots` or `-u`: Update the golden images / reference snapshots of your visual comparison and snapshot tests.
 - `--verbose` or `-v`: Always show the full logs of the checks.
@@ -134,6 +135,7 @@ they contain all the specified tags. Multiple `--tags` flags can be passed, in w
 match any of the `--tag`s filters, i.e. `--tags production,webapp --tags staging,backend` will run checks with tags
 (production AND webapp) OR (staging AND backend).
 - `--test-session-name` A name to use when storing results in Checkly with `--record`.
+- `--retries`: How many times to retry a failing check run.
 - `--timeout`: A fallback timeout (in seconds) to wait for checks to complete. Default 240.
 - `--verbose` or `-v`: Always show the full logs of the checks.
 

--- a/site/content/docs/cli/constructs-reference.md
+++ b/site/content/docs/cli/constructs-reference.md
@@ -38,8 +38,9 @@ export default defineConfig({
   },
   cli: {
     runLocation: 'eu-west-1',
-    privateRunLocation: 'private-dc1'
-  }
+    privateRunLocation: 'private-dc1',
+    retries: 0,
+  },
 })
 ```
 
@@ -59,8 +60,9 @@ settings apply to your Checks. Takes all [Check properties](#check)
 dedicated docs on checkMatch and testMatch](/docs/cli/using-check-test-match/)
 
 - `cli`: Defaults for CLI commands.
-  - `runLocation`: The default run location when running `npx checkly test`.
-  - `privateRunLocation`: The default private run location when running `npx checkly test`.
+  - `runLocation`: The default run location when running `npx checkly test` and `npx checkly trigger`.
+  - `privateRunLocation`: The default private run location when running `npx checkly test` and `npx checkly trigger`.
+  - `retries`: The number of times to retry a failing check run when running `npx checkly test` and `npx checkly trigger`.
 
 ## `Check`
 

--- a/site/content/docs/cli/constructs-reference.md
+++ b/site/content/docs/cli/constructs-reference.md
@@ -62,7 +62,7 @@ dedicated docs on checkMatch and testMatch](/docs/cli/using-check-test-match/)
 - `cli`: Defaults for CLI commands.
   - `runLocation`: The default run location when running `npx checkly test` and `npx checkly trigger`.
   - `privateRunLocation`: The default private run location when running `npx checkly test` and `npx checkly trigger`.
-  - `retries`: The number of times to retry a failing check run when running `npx checkly test` and `npx checkly trigger`.
+  - `retries`: The number of times to retry a failing check run when running `npx checkly test` and `npx checkly trigger`. 0 by default and maximum 3.
 
 ## `Check`
 


### PR DESCRIPTION
## Affected Components
* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [ ] Docs
* [ ] Learn
* [ ] Other

## Pre-Requisites
* [ ] Code is linted (`npm run lint`)

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
We recently released support for CLI retries in [CLI version 4.8.0](https://github.com/checkly/checkly-cli/releases/tag/4.8.0). This PR adds documentation for the new feature.

In particular, this PR changes the [Command Line Reference page](https://checklyhq-com-git-chrislample-document-cli-retri-e45ad8-checkly.vercel.app/docs/cli/command-line-reference/) and [Constructs Reference page](https://checklyhq-com-git-chrislample-document-cli-retri-e45ad8-checkly.vercel.app/docs/cli/constructs-reference/).
