### PR TITLE
Fix RoR redirect & correct shared steps

### DIFF
--- a/site/content/_shared/otel-api-and-endpoint.md
+++ b/site/content/_shared/otel-api-and-endpoint.md
@@ -2,11 +2,7 @@
 sitemapExclude: true
 ---
 
-First, make sure to switch on the **Basic HTTP Instrumentation**. This will add the necessary headers to your HTTP requests.
-
-![Checkly basic OTEL http instrumentation](/docs/images/otel/otel_basic_instrumentation.png)
-
-Then, toggle on **Send Traces**, grab your OTel API key in the **OTel API keys** section of the [Open Telemetry Integration page in the Checkly app](https://app.checklyhq.com/settings/account/traces) and
+First, toggle on **Send Traces**, grab your OTel API key in the **OTel API keys** section of the [Open Telemetry Integration page in the Checkly app](https://app.checklyhq.com/settings/account/traces) and
 take a note of the endpoint for the region you want to use.
 
 ![Checkly OTEL API keys](/docs/images/otel/otel_send_traces.png)

--- a/site/content/docs/traces-open-telemetry/instrumenting-code/ruby-on-rails.md
+++ b/site/content/docs/traces-open-telemetry/instrumenting-code/ruby-on-rails.md
@@ -11,7 +11,7 @@ menu:
     parent: "Instrument your code with OpenTelemetry"
 beta: true
 aliases:
-  - "/docs/open-telemetry/instrumenting-code/ruby"
+  - "/docs/open-telemetry/instrumenting-code/ruby-on-rails"
 ---
 
 This guide will help you instrument your Ruby on Rails application(s) with OpenTelemetry and send traces to Checkly.


### PR DESCRIPTION
fixes the ruby on rails redirect https://www.checklyhq.com/docs/open-telemetry/instrumenting-code/ruby-on-rails/
correct shared steps to remove enabling the HTTP headers propagation

## Affected Components

* [x] Docs

## Screenshots


Should redirect https://checklyhq-com-git-mda-update-traces-checkly.vercel.app/docs/open-telemetry/instrumenting-code/ruby-on-rails/ properly :) 

and updates from 

![image](https://github.com/user-attachments/assets/3508c501-884b-4200-9d43-eb11f4784fe5)

to

![image](https://github.com/user-attachments/assets/30d190d5-5fea-4887-9ae2-26611df663c6)

