### PR TITLE
jan/static-chrome-channel-requirement

### DIFF
--- a/site/content/docs/browser-checks/_index.md
+++ b/site/content/docs/browser-checks/_index.md
@@ -258,6 +258,15 @@ test('Open the page and take a screenshot', async ({ page }) => {
 {{< /tab >}}
 {{< /tabs >}}
 
+{{< info >}}
+## Static Analysis Requirement
+Checkly performs static analysis on the checks code to determine which browsers are used, 
+it is crucial that the `channel: 'chrome'` or `channel: "chrome"` option is included **directly as a string literal**
+(whitespace is ignored) in your code. This means you should not configure this option dynamically, 
+such as using variables or any other dynamic methods. 
+The explicit inclusion of the `channel: 'chrome'` string literal allows our regular expressions to accurately identify 
+and process the configuration, ensuring seamless integration and operation within our platform.
+{{< /info >}}
 
 ## Next Steps
 - Learn more about [built-in functionalities of Playwright Test](/docs/browser-checks/playwright-test/).

--- a/site/content/docs/browser-checks/_index.md
+++ b/site/content/docs/browser-checks/_index.md
@@ -265,7 +265,7 @@ it is crucial that the `channel: 'chrome'` or `channel: "chrome"` option is incl
 (whitespace is ignored) in your code. This means you should not configure this option dynamically, 
 such as using variables or any other dynamic methods. 
 The explicit inclusion of the `channel: 'chrome'` string literal allows our regular expressions to accurately identify 
-and process the configuration, ensuring seamless integration and operation within our platform.
+and process the configuration.
 {{< /info >}}
 
 ## Next Steps

--- a/site/content/docs/browser-checks/_index.md
+++ b/site/content/docs/browser-checks/_index.md
@@ -258,8 +258,8 @@ test('Open the page and take a screenshot', async ({ page }) => {
 {{< /tab >}}
 {{< /tabs >}}
 
+### Static Analysis Requirement
 {{< info >}}
-## Static Analysis Requirement
 Checkly performs static analysis on the checks code to determine which browsers are used, 
 it is crucial that the `channel: 'chrome'` or `channel: "chrome"` option is included **directly as a string literal**
 (whitespace is ignored) in your code. This means you should not configure this option dynamically, 


### PR DESCRIPTION
## Affected Components
* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [x] Docs
* [ ] Learn
* [ ] Other

## Pre-Requisites
* [ ] Code is linted (`npm run lint`)

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
* Due to the introduction of ARM instances we need to make sure that customers explicitly include the `channel: chrome` in their code for static analysis
* We checked every check that used chrome in the last 7 days and all of them will meet this requirement
* Also we have a nice error message explaining this requirement if a Chrome check accidentally lands on an ARM node
* We also have logs in our own logstream - we'll be able to track this 

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->

## Screenshots
![CleanShot 2024-08-06 at 11 38 59](https://github.com/user-attachments/assets/8e94ef4a-0829-4f06-a9b1-df49be48f9be)


