### PR TITLE
Added param for navTitle to be used in the menu of the docs

### DIFF
--- a/site/content/docs/traces-open-telemetry/_index.md
+++ b/site/content/docs/traces-open-telemetry/_index.md
@@ -5,6 +5,7 @@ menu:
   platform:
     parent: "Traces (beta)"
     identifier: getting-started-traces-otel
+navTitle: Getting started
 beta: true
 aliases:
   - "/docs/open-telemetry/"

--- a/site/layouts/partials/docs-title.html
+++ b/site/layouts/partials/docs-title.html
@@ -1,6 +1,7 @@
 {{ $title := "" }}
-
-{{ if .Page.Params.displayTitle}}
+{{ if .Page.Params.navTitle}}
+  {{ $title = .Page.Params.navTitle}}
+{{ else if .Page.Params.displayTitle}}
   {{ $title = .Page.Params.displayTitle}}
 {{ else if .Title }}
   {{ $title = .Title }}


### PR DESCRIPTION
## Affected Components
* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [ X ] Docs
* [ ] Learn
* [ ] Other

## Pre-Requisites
* [ X ] Code is linted (`npm run lint`)

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer

The title of the documentation page is now separated from the title that appears on the sidebar menu. Each documentation page now has a param called `navTitle` that dictates the title of the sidebar menu.
## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->

## Screenshots
<!-- Screenshot of any visual changes -->
<img width="1205" alt="image" src="https://github.com/user-attachments/assets/75d54ed2-be08-4909-b812-f10caeb3c060">

You can see that the title on the sidebarnav of this page is different than the page H1.
