### PR TITLE
Reducing Title Tag size in template

### DIFF
--- a/site/layouts/partials/head.html
+++ b/site/layouts/partials/head.html
@@ -1,13 +1,21 @@
 <head>
-  <title>
-    {{$title := "Checkly Documentation"}}
-    {{ if .IsHome }}{{ $title = .Site.Title }}{{ else if .Params.head.title }}{{ $title =.Params.head.title }}{{ else }}{{ $title = .Title }}{{ end }}     
-    {{$titleLength := $title | len}}
-    {{if lt $titleLength 50}}
-    {{$title}} | Checkly
-    {{else}}
-    {{$title}}
-    {{end}}</title>
+  {{ if .IsHome }}
+<title>{{ .Site.Title }} | Checkly</title>
+{{ else if .Params.head.title }}
+<title>{{ .Params.head.title }} | Checkly</title>
+{{ else }}
+<title>{{ .Title }} | Checkly</title>
+{{ end }}
+
+{{$title := ""}}
+{{ if .IsHome }}{{$title = .Site.Title}}{{ else if .Params.head.title }}{{$title = .Params.head.title}}{{ else }}{{$title = .Title}}{{ end }}
+{{$titleLength := $title | len}}
+
+{{ if lt $titleLength 50 }}
+<title>{{$title}} | Checkly</title>
+{{ else }}
+<title>{{$title}}</title>
+{{ end }}
   <meta charset="utf-8" />
   <meta name="description" content="{{ with .Description }}{{ . | markdownify }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . | markdownify}}{{ end }}{{ end }}{{ end }}" />
   <meta name="viewport" content="width=device-width" initial-scale="1" maximum-scale="1" />


### PR DESCRIPTION
## Affected Components
* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [ ] Docs
* [ X ] Learn
* [ ] Other

## Pre-Requisites
* [ ] Code is linted (`npm run lint`)

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
This first commit tries to fix the elongated Meta TItle Tags in our Hugo template
## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->

## Screenshots
<!-- Screenshot of any visual changes -->
