### PR TITLE
refactor: removes unneeded playwright tabs [sc-00]

### DIFF
--- a/site/content/learn/playwright/challenging-flows.md
+++ b/site/content/learn/playwright/challenging-flows.md
@@ -45,19 +45,13 @@ Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36
 
 Bot detection could be deactivated for pre-production environments in order to allow automation. For production environments, a secret may be included in the User-Agent (or similar mechanism) for the system to recognize test bots and allow them through:
 
-{{< tabs "1">}}
-{{< tab "Playwright" >}}
 ```js
 const browser = await chromium.launch()
 const context = await browser.newContext({
   userAgent: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/79.0.3945.0 Safari 537.36 Secret/<MY_SECRET>'
 })
 const page = await context.newPage('https://example.com')
-
 ```
-{{< /tab >}}
-
-{{< /tabs >}}
 
 ## Automation-resistant UIs
 Certain industries are particularly affected by malicious automation attempts, especially where high-volume automation offers an unfair advantage. Examples of this include online betting and gaming.

--- a/site/content/learn/playwright/checkout-testing-guide.md
+++ b/site/content/learn/playwright/checkout-testing-guide.md
@@ -26,15 +26,10 @@ Checkout procedures can vary dramatically depending on what is being bought or s
 
 Modelled on the above structure is the following example running against our test website. We will add a few products to the shopping cart, then proceed until the summary screen shows up and verify that the transaction has been confirmed. Here we can get creative and, for example, iterate through a number of products to fill the cart:
 
-{{< tabs "1">}}
-{{< tab "Playwright" >}}
 ```js
-{{< readfile filename="samples/playwright/checkout.js" >}}
+{{% readfile filename="samples/playwright/checkout.js" %}}
 ```
 {{< run-in-checkly "/samples/playwright/checkout.js" "playwright"  >}}
-{{< /tab >}}
-
-{{< /tabs >}}
 
 Run this example as follows:
 

--- a/site/content/learn/playwright/emulating-mobile-devices.md
+++ b/site/content/learn/playwright/emulating-mobile-devices.md
@@ -28,8 +28,6 @@ This guide explains how to define viewport sizes, device pixel ratio and  `user-
 
 If your site parses the user agent string to serve a different experience to mobile users, define the `userAgent` in your automation scripts.
 
-
-
 ```js
 const { chromium } = require("playwright")
 
@@ -48,11 +46,9 @@ const { chromium } = require("playwright")
 })()
 ```
 
-
 ## Defining viewport size and pixel density
 
 If your site follows responsive web design practices and renders elements depending on device viewport size, define a mobile viewport and pixel density.
-
 
 ```js
 const { chromium } = require("playwright")
@@ -100,7 +96,6 @@ const iPhone = devices['iPhone SE'];
   await browser.close()
 })()
 ```
-
 
 ## Further reading
 

--- a/site/content/learn/playwright/file-download.md
+++ b/site/content/learn/playwright/file-download.md
@@ -30,26 +30,17 @@ We will check that the downloaded file is as expected by comparing it to a [fixt
 
 We can approach this scenario in different ways. One possibility is to perform the first two steps, then [extract](/learn/playwright/web-scraping/) the `href` value and use it to retrieve the file with a `GET` request (performed with [axios](https://github.com/axios/axios), for example).
 
-{{< tabs "1" >}}
-{{< tab "Playwright" >}}
 ```js {hl_lines=["23-28"]}
-{{< readfile filename="samples/playwright/file-download.js" >}}
+{{% readfile filename="samples/playwright/file-download.js" %}}
 ```
-{{< /tab >}}
-
-{{< /tabs >}}
 
 We could also click the link directly and wait for the download event, then proceed with the comparison.
 
 Note that in this case, we need to enable downloads in the browser context before proceeding.
 
-{{< tabs "2" >}}
-{{< tab "Playwright" >}}
 ```js {hl_lines=["8", "23-26"]}
-{{< readfile filename="samples/playwright/file-download-alt.js" >}}
+{{% readfile filename="samples/playwright/file-download-alt.js" %}}
 ```
-{{< /tab >}}
-{{< /tabs >}}
 
 Both examples can be run as follows:
 {{< tabs "3" >}}

--- a/site/content/learn/playwright/generating-pdfs.md
+++ b/site/content/learn/playwright/generating-pdfs.md
@@ -23,14 +23,10 @@ This article introduces this functionality and shows how we can customise the PD
 
 After loading a page, we use the `page.pdf()` command to convert it to a PDF.
 
-{{< tabs "1" >}}
-{{< tab "Playwright" >}}
-```js {hl_lines=[7]}
-{{< readfile filename="samples/playwright/pdf-minimal.js" >}}
-``` 
-{{< /tab >}}
-{{< /tabs >}}
 
+```js {hl_lines=[7]}
+{{% readfile filename="samples/playwright/pdf-minimal.js" %}}
+```
 
 Note that we need to pass the `path` option to have the PDF file actually saved to disk.
 
@@ -51,14 +47,9 @@ In certain cases, our webpage might look significantly different in our PDF comp
 
 We can also have custom headers and footers added to our pages, displaying values such as title, page number and more. Let's see how this looks on your [favourite website](https://www.checklyhq.com/):
 
-
-{{< tabs "2" >}}
-{{< tab "Playwright" >}}
 ```js {hl_lines=["11-12","18-31"]}
-{{< readfile filename="samples/playwright/pdf-hd.js" >}}
+{{% readfile filename="samples/playwright/pdf-hd.js" %}}
 ```
-{{< /tab >}}
-{{< /tabs >}}
 
 We are including the following template files for our header and footer.
 

--- a/site/content/learn/playwright/google-login-automation.md
+++ b/site/content/learn/playwright/google-login-automation.md
@@ -26,14 +26,9 @@ Social login using your personal Google or Google Gsuite account is a common use
 4. We provide the username and password, injected by using environment variables.
 5. We are redirected back to the starting.
 
-{{< tabs "1" >}}
-{{< tab "Playwright" >}}
 ```js
-{{< readfile filename="samples/playwright/google-login.js" >}}
+{{% readfile filename="samples/playwright/google-login.js" %}}
 ```
-{{< /tab >}}
-
-{{< /tab >}}:
 
 Run this example as follows. Replace the username and password placeholder with your own credentials.
 

--- a/site/content/learn/playwright/how-to-search.md
+++ b/site/content/learn/playwright/how-to-search.md
@@ -28,15 +28,10 @@ The example below, which is running against our [test webshop](https://danube-we
 
 We will use [Chai](https://www.chaijs.com/api/assert/) as an assertion library for points 2 and 3.
 
-{{< tabs "1" >}}
-{{< tab "Playwright" >}}
 ```js
-{{< readfile filename="samples/playwright/search.js" >}}
+{{% readfile filename="samples/playwright/search.js" %}}
 ```
 {{< run-in-checkly "/samples/playwright/search.js" "playwright"  >}}
-{{< /tab >}}
-
-{{< /tabs >}}
 
 Run this example as follows:
 

--- a/site/content/learn/playwright/how-to-set-up-locally.md
+++ b/site/content/learn/playwright/how-to-set-up-locally.md
@@ -24,16 +24,10 @@ $ npm i playwright
 
 Playwright comes bundled with a connected browser, so we now have all we need to run our first script. Let's create a script to navigate to our [test website](https://danube-web.shop/):
 
-{{< tabs "1" >}}
-
-{{< tab "Playwright" >}}
 ```js
-{{< readfile filename="samples/playwright/basic-navigation.js" >}}
+{{% readfile filename="samples/playwright/basic-navigation.js" %}}
 ```
 {{< run-in-checkly "/samples/playwright/basic-navigation.js" "playwright"  >}}
-{{< /tab >}}
-
-{{< /tabs >}}
 
 Run this example as follows:
 ```sh
@@ -47,15 +41,10 @@ Nothing much has happened, right? Remember: by default, Playwright will run in h
 
 When you are first writing and debugging your scripts, it is a good idea to disable headless mode, so you can have a look at what your script is doing:
 
-{{< tabs "2" >}}
 
-{{< tab "Playwright" >}}
 ```js
 const browser = await chromium.launch({ headless: false })
 ```
-{{< /tab >}}
-
-{{< /tabs >}}
 
 After executing the updated file, you will see Chromium starting up, only to shut down after an instant. Everything is working as expected! Our script is just so short, it runs almost instantaneously.
 

--- a/site/content/learn/playwright/iframe-interaction.md
+++ b/site/content/learn/playwright/iframe-interaction.md
@@ -19,14 +19,9 @@ Playwright enables us to access and interact with iframes.
 
 To access iframe elements, locate the iframe and query the DOM elements as if you're in the page context.
 
-{{< tabs "1" >}}
-{{< tab "Playwright" >}}
 ```js
-{{< readfile filename="samples/playwright/iframe-access.js" >}}
+{{% readfile filename="samples/playwright/iframe-access.js" %}}
 ```
-{{< /tab >}}
-
-{{< /tabs >}}
 
 ## Further reading
 

--- a/site/content/learn/playwright/intercept-requests.md
+++ b/site/content/learn/playwright/intercept-requests.md
@@ -25,25 +25,18 @@ When we browse the web, a series of HTTP requests and responses are exchanged be
 
 Request interception enables us to observe which requests and responses are being exchanged as part of our script's execution. For example, this is how we could print them out when we load our [test website](https://danube-web.shop/):
 
-{{< tabs "1" >}}
-{{< tab "Playwright" >}}
 ```js
-{{< readfile filename="samples/playwright/request-interception-read.js" >}}
+{{% readfile filename="samples/playwright/request-interception-read.js" %}}
 ```
 {{< run-in-checkly "/samples/playwright/request-interception-read.js" "playwright"  >}}
-{{< /tab >}}
-{{< /tabs >}}
+
 
 We might want to intervene and filter the outgoing requests. For example, when [scraping web pages](/learn/playwright/web-scraping/), we might want to block unnecessary elements from loading in order to speed up the procedure and lower bandwidth usage.
 
-
-{{< tabs "2" >}}
-{{< tab "Playwright" >}}
 ```js {hl_lines=["11-13", "16-20"]}
-{{< readfile filename="samples/playwright/request-interception-block.js" >}}
+{{% readfile filename="samples/playwright/request-interception-block.js" %}}
 ```
 {{< run-in-checkly "/samples/playwright/request-interception-block.js" "playwright"  >}}
-{{< /tabs >}}
 
  As a result, you will see the website logo not being loaded.
 
@@ -61,14 +54,10 @@ Playwright makes it easy for us, as for every request we can intercept we also c
 
 Every time we load it, our test website is sending a request to its backend to fetch a list of best selling books. For our example, we are going to intercept this response and modify it to return a single book we define on the fly.
 
-{{< tabs "3" >}}
-{{< tab "Playwright" >}}
 ```js {hl_lines=[18,23]}
-{{< readfile filename="samples/playwright/response-interception.js" >}}
+{{% readfile filename="samples/playwright/response-interception.js" %}}
 ```
 {{< run-in-checkly "/samples/playwright/response-interception.js" "playwright"  >}}
-{{< /tab >}}
-{{< /tabs >}}
 
 Here is what the homepage will look like with our stubbed response:
 

--- a/site/content/learn/playwright/login-automation.md
+++ b/site/content/learn/playwright/login-automation.md
@@ -31,14 +31,9 @@ At the end of our test, we need to check if our login procedure has been success
 
 On our [test site](https://danube-web.shop/) this could look like the following:
 
-{{< tabs "1" >}}
-{{< tab "Playwright" >}}
 ```js
-{{< readfile filename="samples/playwright/login.js" >}}
+{{% readfile filename="samples/playwright/login.js" %}}
 ```
-{{< /tab >}}
-
-{{< /tabs >}}
 
 Run this example as follows. Replace the username and password placeholder with your own credentials.
 

--- a/site/content/learn/playwright/managing-cookies.md
+++ b/site/content/learn/playwright/managing-cookies.md
@@ -25,14 +25,9 @@ Reading or modifying cookies opens up useful possibilities. A practical example 
 
 The following examples show how we can save existing cookies after logging in to GitHub and reuse them later to skip login. First, let us perform login with our credentials, read the cookies and save them to a file.
 
-
-{{< tabs "1" >}}
-{{< tab "Playwright" >}}
 ```js {hl_lines=[21,22,24]}
-{{< readfile filename="samples/playwright/cookies-reading.js" >}}
+{{% readfile filename="samples/playwright/cookies-reading.js" %}}
 ```
-{{< /tab >}}
-{{< /tabs >}}
 
 After a successful login, our saved cookies file will look something like this:
 
@@ -70,16 +65,9 @@ After a successful login, our saved cookies file will look something like this:
 
 We are now able to read the file later and load the cookies into our new browser session. Notice how we are logged in from the start, without having gone through the UI login procedure.
 
-
-
-{{< tabs "2" >}}
-{{< tab "Playwright" >}}
 ```js {hl_lines=[9,11,12]}
-{{< readfile filename="samples/playwright/cookies-writing.js" >}}
+{{% readfile filename="samples/playwright/cookies-writing.js" %}}
 ```
-{{< /tab >}}
-{{< /tabs >}}
-
 
 > Cookies come with an expiration date, so make sure the ones you are trying to reuse are still valid.
 
@@ -98,13 +86,9 @@ Our test site, [Danube](https://danube-web.shop/), actually uses localStorage to
 
 We will first fill the cart by adding three items, then we will copy the contents of localStorage to a file.
 
-{{< tabs "3" >}}
-{{< tab "Playwright" >}}
 ```js {hl_lines=[17,18]}
-{{< readfile filename="samples/playwright/localstorage-reading.js" >}}
+{{% readfile filename="samples/playwright/localstorage-reading.js" %}}
 ```
-{{< /tab >}}
-{{< /tabs >}}
 
 In this case our file will look as follows:
 
@@ -116,14 +100,10 @@ In this case our file will look as follows:
 
 We can use the content of this file to set localStorage in a separate session. That way we will immediately start with the three items already in our shopping cart, potentially getting us closer to a specific scenario we want to test and thereby saving ourselves time.
 
-{{< tabs "4" >}}
-{{< tab "Playwright" >}}
 ```js {hl_lines=[10,"12-17"]}
 
-{{< readfile filename="samples/playwright/localstorage-writing.js" >}}
+{{% readfile filename="samples/playwright/localstorage-writing.js" %}}
 ```
-{{< /tab >}}
-{{< /tabs >}}
 
 You can interact with sessionStorage very much like we did with localStorage.
 

--- a/site/content/learn/playwright/microsoft-login-automation.md
+++ b/site/content/learn/playwright/microsoft-login-automation.md
@@ -24,14 +24,9 @@ Playwright allows us to automate logging in to a Microsoft Live account.
 2. We provide the username and password, injected by using environment variables
 3. We are redirected to the main account page
 
-{{< tabs "1" >}}
-{{< tab "Playwright" >}}
 ```js
-{{< readfile filename="samples/playwright/mslive-login.js" >}}
+{{% readfile filename="samples/playwright/mslive-login.js" %}}
 ```
-{{< /tab >}}
-{{< /tab >}}
-
 Run this example as follows. Replace the username and password placeholder with your own credentials.
 
 {{< tabs "2" >}}

--- a/site/content/learn/playwright/multitab-flows.md
+++ b/site/content/learn/playwright/multitab-flows.md
@@ -20,15 +20,10 @@ Playwright enables us to control multiple browser tabs, albeit in different ways
 
 If we are looking to open brand new tabs with which to interact, the setup is rather straightforward.
 
-{{< tabs "1" >}}
-{{< tab "Playwright" >}}
 ```js
-{{< readfile filename="samples/playwright/multitab-open.js" >}}
+{{% readfile filename="samples/playwright/multitab-open.js" %}}
 ```
 {{< run-in-checkly "/samples/playwright/multitab-open.js" "playwright"  >}}
-{{< /tab >}}
-
-{{< /tabs >}}
 
 ## Handling links that open a new tab
 
@@ -36,18 +31,10 @@ Controlling tabs that are opened after a click on an element on the page can be 
 
 By allowing us to wait for the creation of a child tab with `page.waitForEvent`, Playwright enables us to "catch" it following a click on an element with `target="_blank"`, and then seamlessly interact with any of the currently open tabs. 
 
-
-{{< tabs "2" >}}
-{{< tab "Playwright" >}}
 ```js
-{{< readfile filename="samples/playwright/multitab-flows.js" >}}
+{{% readfile filename="samples/playwright/multitab-flows.js" %}}
 ```
 {{< run-in-checkly "/samples/playwright/multitab-flows.js" "playwright"  >}}
-{{< /tab >}}
-
-{{< /tabs >}}
-
-
 
 ## Further reading
 

--- a/site/content/learn/playwright/navigation.md
+++ b/site/content/learn/playwright/navigation.md
@@ -39,15 +39,10 @@ In the example below we trigger two navigations:
 1. The initial load of the page.
 2. A navigation to the shopping cart by clicking a link
 
-{{< tabs "1" >}}
-{{< tab "Playwright" >}}
 ```js
-{{< readfile filename="samples/playwright/basic-browser-navigation.js" >}}
+{{% readfile filename="samples/playwright/basic-browser-navigation.js" %}}
 ```
 {{< run-in-checkly "/samples/playwright/basic-browser-navigation.js" "playwright"  >}}
-{{< /tab >}}
-
-{{< /tabs >}}
 
 Run this example as follows:
 ```sh
@@ -71,15 +66,9 @@ to override the default 30 seconds.
 
 In the example below, we type an email address into an input field on a login modal. Playwright's `fill` method comes with built-in waiting functionality.
 
-{{< tabs "2" >}}
-{{< tab "Playwright" >}}
 ```js
-{{< readfile filename="samples/playwright/basic-browser-waiting.js" >}}
+{{% readfile filename="samples/playwright/basic-browser-waiting.js" %}}
 ```
-{{< /tab >}}
-
-{{< /tabs >}}
-
 Run this example as follows:
 
 ```shell script

--- a/site/content/learn/playwright/performance.md
+++ b/site/content/learn/playwright/performance.md
@@ -76,14 +76,12 @@ The Navigation Timing and the Resource Timing performance APIs are W3C specifica
 
 [The Navigation Timing API](https://developer.mozilla.org/en-US/docs/Web/API/Navigation_timing_API) allows us to retrieve timestamps of key events in the page load timeline. A Navigation Timing entry includes metrics such as the navigation response time, the used protocol and document load time.
 
-{{< tabs "1" >}}
-{{< tab "Playwright" >}}
+
 ```js
-{{< readfile filename="samples/playwright/basic-performance-navigation.js" >}}
+{{% readfile filename="samples/playwright/basic-performance-navigation.js" %}}
 ```
 {{< run-in-checkly "/samples/playwright/basic-performance-navigation.js" "playwright"  >}}
-{{< /tab >}}
-{{< /tabs >}}
+
 
 <details class="console-output">
   <summary>Console output</summary>
@@ -126,15 +124,11 @@ The Navigation Timing and the Resource Timing performance APIs are W3C specifica
 
 [The Resource Timing API](https://developer.mozilla.org/en-US/docs/Web/API/Resource_Timing_API/Using_the_Resource_Timing_API) allows us to zoom in on single resources and get accurate information about how quickly they loaded. For example, we could specifically look at our website's logo:
 
-{{< tabs "2" >}}
-{{< tab "Playwright" >}}
+
 ```js
-{{< readfile filename="samples/playwright/basic-performance-resource.js" >}}
+{{% readfile filename="samples/playwright/basic-performance-resource.js" %}}
 ```
 {{< run-in-checkly "/samples/playwright/basic-performance-resource.js" "playwright"  >}}
-{{< /tab >}}
-
-{{< /tabs >}}
 
 <details class="console-output">
   <summary>Console output</summary>
@@ -169,15 +163,10 @@ The Navigation Timing and the Resource Timing performance APIs are W3C specifica
 
 [The Paint Timing API](https://developer.mozilla.org/en-US/docs/Web/API/PerformancePaintTiming) provides information on the first paint and the first contentful paint. Access the entries via `performance.getEntriesByType('paint')` or `performance.getEntriesByName('first-contentful-paint')`.
 
-{{< tabs "3" >}}
-{{< tab "Playwright" >}}
 ```js
-{{< readfile filename="samples/playwright/basic-performance-paint-timing.js" >}}
+{{% readfile filename="samples/playwright/basic-performance-paint-timing.js" %}}
 ```
 {{< run-in-checkly "/samples/playwright/basic-performance-paint-timing.js" "playwright"  >}}
-{{< /tab >}}
-
-{{< /tabs >}}
 
 <details class="console-output">
   <summary>Console output</summary>
@@ -197,15 +186,11 @@ Large contentful paints are not a single event but rather event streams. A large
 To evaluate the LCP initialize a `PerformanceObserver`, observe `largest-contentful-paint` entries and access the last emitted paint.
 {{</ info >}}
 
-{{< tabs "4" >}}
-{{< tab "Playwright" >}}
 ```js
-{{< readfile filename="samples/playwright/basic-performance-largest-contentful-paint.js" >}}
+{{% readfile filename="samples/playwright/basic-performance-largest-contentful-paint.js" %}}
 ```
 {{< run-in-checkly "/samples/playwright/basic-performance-largest-contentful-paint.js" "playwright"  >}}
-{{< /tab >}}
 
-{{< /tabs >}}
 #### Layout Instability API (`layout-shift`)
 
 [The Layout Instability API](https://developer.mozilla.org/en-US/docs/Web/API/Layout_Instability_API) provides information on all layout shifts. Use this API to evaluate the Core Web Vital [Cumulative Layout Shift](https://web.dev/cls/) (CLS).
@@ -214,15 +199,10 @@ To evaluate the LCP initialize a `PerformanceObserver`, observe `largest-content
 Layout shifts are no single event but event streams. To calculate CLS initialize a `PerformanceObserver`, observe `layout-shift` entries and sum all shifts.
 {{</ info >}}
 
-{{< tabs "5" >}}
-{{< tab "Playwright" >}}
 ```js
-{{< readfile filename="samples/playwright/basic-performance-layout-shift.js" >}}
+{{% readfile filename="samples/playwright/basic-performance-layout-shift.js" %}}
 ```
 {{< run-in-checkly "/samples/playwright/basic-performance-layout-shift.js" "playwright"  >}}
-{{< /tab >}}
-
-{{< /tabs >}}
 
 #### Long Task API (`longtask`)
 
@@ -232,15 +212,11 @@ Layout shifts are no single event but event streams. To calculate CLS initialize
 Long Tasks are no single event but event streams. To calculate TBT initialize a `PerformanceObserver`, observe `longtasks` entries and sum the differences to the maximal JavaScript execution time of 50 milliseconds.
 {{</ info >}}
 
-{{< tabs "6" >}}
-{{< tab "Playwright" >}}
 ```js
-{{< readfile filename="samples/playwright/basic-performance-long-task.js" >}}
+{{% readfile filename="samples/playwright/basic-performance-long-task.js" %}}
 ```
 {{< run-in-checkly "/samples/playwright/basic-performance-long-task.js" "playwright"  >}}
-{{< /tab >}}
 
-{{< /tabs >}}
 
 ### Chrome DevTools for performance
 
@@ -248,15 +224,10 @@ If the browser performance APIs are not enough, the Chrome DevTools Protocol off
 
 One important example is network throttling, through which we can simulate the experience of users accessing our page with different network conditions.
 
-{{< tabs "7" >}}
-{{< tab "Playwright" >}}
 ```js
-{{< readfile filename="samples/playwright/basic-performance-emulation.js" >}}
+{{% readfile filename="samples/playwright/basic-performance-emulation.js" %}}
 ```
 {{< run-in-checkly "/samples/playwright/basic-performance-emulation.js" "playwright"  >}}
-{{< /tab >}}
-
-{{< /tabs >}}
 
 The DevTools Protocol is quite extensive. We recommend exploring the [documentation](https://chromedevtools.github.io/devtools-protocol/) and getting a comprehensive overview of its capabilities.
 
@@ -264,13 +235,9 @@ The DevTools Protocol is quite extensive. We recommend exploring the [documentat
 
 Lighthouse can easily be used programmatically with Playwright to gather values and scores for different metrics, like [Time To Interactive (TTI)](https://web.dev/interactive/):
 
-{{< tabs "8" >}}
-{{< tab "Playwright" >}}
 ```js
-{{< readfile filename="samples/playwright/basic-performance-lighthouse.js" >}}
+{{% readfile filename="samples/playwright/basic-performance-lighthouse.js" %}}
 ```
-{{< /tab >}}
-{{< /tabs >}}
 
 All above examples can be run as follows:
 ```sh

--- a/site/content/learn/playwright/playwright-vs-cypress.md
+++ b/site/content/learn/playwright/playwright-vs-cypress.md
@@ -144,7 +144,6 @@ test('Multiple API Requests Test', async ({ request }) => {
   const userResponse = await request.get('https://jsonplaceholder.typicode.com/users/1');
   expect(userResponse.status()).toBe(200);
 });
-
 ```
 
 Playwright uses the standard `await` syntax used in the rest of Node.js. 
@@ -164,7 +163,6 @@ describe('Multiple API Requests Test', () => {
       .should('eq', 200);
   });
 });
-
 ```
 With Cypress, we're using their custom syntax, which is a bit more compact but still has it's own specialized field of knowledge. If you're pursuing a monitoring as code strategy and getting everyone involved in testing and monitoring, this domain-specific syntax may be a barrier to entry.
 

--- a/site/content/learn/playwright/playwright-vs-selenium.md
+++ b/site/content/learn/playwright/playwright-vs-selenium.md
@@ -35,7 +35,6 @@ Playwright is a relatively new browser automation framework that has gained popu
     
     ```bash
     npm install --save-dev playwright
-    
     ```
     
 2. Set up a test script using `@playwright/test`:
@@ -48,14 +47,12 @@ Playwright is a relatively new browser automation framework that has gained popu
       const title = await page.title();
       expect(title).toBe('Example Domain');
     });
-    
     ```
     
 3. Run the test with the Playwright CLI:
     
     ```bash
     npx playwright test
-    
     ```
     
 
@@ -127,7 +124,6 @@ Here’s how to run a Selenium test in NodeJS
     
     // Run the test
     exampleTest();
-    
     ```
     
 
@@ -244,7 +240,6 @@ async function loginAndCaptureScreenshot() {
 
 // Run the test
 loginAndCaptureScreenshot();
-
 ```
 
 Some key differences in the two examples:

--- a/site/content/learn/playwright/scraping-behind-login.md
+++ b/site/content/learn/playwright/scraping-behind-login.md
@@ -23,14 +23,9 @@ For our example, we will be logging in to our Amazon account and scraping the pr
 
 A combination of UI automation and scraping will allow us to first log in to the platform, and then to retrieve the information about all our orders.
 
-{{< tabs "1" >}}
-{{< tab "Playwright" >}}
 ```js
-{{< readfile filename="samples/playwright/scraping-example-purchases.js" >}}
+{{% readfile filename="samples/playwright/scraping-example-purchases.js" %}}
 ```
-{{< /tab >}}
-
-{{< /tabs >}}
 
 > ⚠️ This example is only intended for learning purposes. Always make sure the website you are planning to scrape allows such behaviour.
 

--- a/site/content/learn/playwright/taking-screenshots.md
+++ b/site/content/learn/playwright/taking-screenshots.md
@@ -22,14 +22,10 @@ Headless browsers are fully capable of taking screenshots, which is very useful 
 
 The `page.screenshot` command allows us to save one or more screenshots of the current page to a specified path. Without any additional options, the size of the screenshot depends on the viewport size:
 
-{{< tabs "1" >}}
-{{< tab "Playwright" >}}
 ```js
-{{< readfile filename="samples/playwright/basic-screenshot.js" >}}
+{{% readfile filename="samples/playwright/basic-screenshot.js" %}}
 ```
 {{< run-in-checkly "/samples/playwright/basic-screenshot.js" "playwright"  >}}
-{{< /tab >}}\s
-{{< /tabs >}}
 
 ## Full page screenshots
 
@@ -43,15 +39,10 @@ await page.screenshot({ path: 'my_screenshot.png', fullPage: true })
 
 Having our screenshot limited to a smaller portion of the viewport is also possible. All we need to do is specify the coordinates of the top left corner of the screenshot, plus `width` and `height`. We then pass these options to:
 
-{{< tabs "2" >}}
-{{< tab "Playwright" >}}
 ```js
-{{< readfile filename="samples/playwright/basic-screenshot-clipped.js" >}}
+{{% readfile filename="samples/playwright/basic-screenshot-clipped.js" %}}
 ```
 {{< run-in-checkly "/samples/playwright/basic-screenshot-clipped.js" "playwright"  >}}
-{{< /tab >}}
-
-{{< /tabs >}}
 
 The above examples can be run as follows:
 ```sh

--- a/site/content/learn/playwright/testing-account-settings.md
+++ b/site/content/learn/playwright/testing-account-settings.md
@@ -26,15 +26,9 @@ Account properties to verify can run the gamut from simple text to connected thi
 
 On our [test site](https://danube-web.shop/), such a test could look as follows:
 
-{{< tabs "1">}}
-{{< tab "Playwright" >}}
 ```js {hl_lines=["19-22"]}
-{{< readfile filename="samples/playwright/file-upload.js" >}}
+{{% readfile filename="samples/playwright/file-upload.js" %}}
 ```
-{{< /tab >}}
-
-{{< /tabs >}}
-
 {{< tabs "2">}}
 {{< tab "macOS" >}}
 ```sh

--- a/site/content/learn/playwright/testing-coupons.md
+++ b/site/content/learn/playwright/testing-coupons.md
@@ -26,15 +26,11 @@ While discount coupons will be applied in different ways depending on the servic
 
 The following example, running against our [test site](https://danube-web.shop/), will add a variable number of items to the cart, then proceed to compare the total price before and after applying the coupon. The coupon is reducing the price of the whole shopping cart by 20%, therefore we will be asserting that the discounted price is reduced by the right amount. For this step we have chosen [Chai](https://www.chaijs.com/api/assert/), but any solid assertion library will do.
 
-{{< tabs "1" >}}
-{{< tab "Playwright" >}}
+
 ```js
-{{< readfile filename="samples/playwright/coupon.js" >}}
+{{% readfile filename="samples/playwright/coupon.js" %}}
 ```
 {{< run-in-checkly "/samples/playwright/coupon.js" "playwright"  >}}
-{{< /tab >}}
-
-{{< /tabs >}}
 
 Run this example as follows:
 

--- a/site/content/learn/playwright/user-signup-automation.md
+++ b/site/content/learn/playwright/user-signup-automation.md
@@ -30,13 +30,9 @@ The flow will often match the following:
 
 We will likely want to also check that some change occurred in the UI to confirm that the registration worked.
 
-{{< tabs "1" >}}
-{{< tab "Playwright" >}}
 ```js
-{{< readfile filename="samples/playwright/signup.js" >}}
+{{% readfile filename="samples/playwright/signup.js" %}}
 ```
-{{< /tab >}}
-{{< /tabs >}}
 
 Run this example as follows:
 {{< tabs "2" >}}

--- a/site/content/learn/playwright/web-scraping.md
+++ b/site/content/learn/playwright/web-scraping.md
@@ -27,26 +27,17 @@ We call the action of extracting data from web pages _web scraping_. Scraping is
 
 Below is an example running against our [test site](https://danube-web.shop/), getting and printing out the `href` attribute of the first `a` element on the homepage. That just happens to be our logo, which links right back to our homepage, and therefore will have an `href` value equal to the URL we navigate to using `page.goto()`:
 
-{{< tabs "1" >}}
-{{< tab "Playwright" >}}
-```js 7
-{{< readfile filename="samples/playwright/basic-get-href-value.js" >}}
+```js {hl_lines=["8"]}
+{{% readfile filename="samples/playwright/basic-get-href-value.js" %}}
 ```
 {{< run-in-checkly "/samples/playwright/basic-get-href-value.js" "playwright"  >}}
-{{< /tab >}}
-{{< /tabs >}}
 
 As an alternative, it is also possible to retrieve an [ElementHandle](https://playwright.dev/docs/api/class-elementhandle) and then retrieve a property value from it. Following is an example printing the `href` value of the first `a` element of our homepage:
 
-{{< tabs "2" >}}
-{{< tab "Playwright" >}}
-```js 7,8
-{{< readfile filename="samples/playwright/basic-get-href-handle.js" >}}
+```js {hl_lines=["7-8"]}
+{{% readfile filename="samples/playwright/basic-get-href-handle.js" %}}
 ```
 {{< run-in-checkly "/samples/playwright/basic-get-href-handle.js" "playwright"  >}}
-{{< /tab >}}
-
-{{< /tabs >}}
 
 > The `innerText` property is often used in tests to assert that some element on the page contains the expected text.
 
@@ -54,27 +45,20 @@ As an alternative, it is also possible to retrieve an [ElementHandle](https://pl
 
 Scraping element lists is just as easy. For example, let's grab the `innerText` of each product category shown on the homepage:
 
-{{< tabs "3" >}}
-{{< tab "Playwright" >}}
-```js 7-9
-{{< readfile filename="samples/playwright/basic-get-text-values.js" >}}
+```js {hl_lines=["7-9"]}
+{{% readfile filename="samples/playwright/basic-get-text-values.js" %}}
 ```
 {{< run-in-checkly "/samples/playwright/basic-get-text-values.js" "playwright"  >}}
-{{< /tab >}}
-{{< /tabs >}}
 
 ## Scraping images
 
 Scraping images from a page is also possible. For example, we can easily get the logo of our test website and save it as a file:
 
-{{< tabs "4" >}}
-{{< tab "Playwright" >}}
-```js [9,11,12]
-{{< readfile filename="samples/playwright/basic-get-image.js" >}}
+```js {hl_lines=["10", "12-13"]}
+{{% readfile filename="samples/playwright/basic-get-image.js" %}}
 ```
 {{< run-in-checkly "/samples/playwright/basic-get-image.js" "playwright"  >}}
-{{< /tab >}}
-{{< /tabs >}}
+
 
 We are using [axios](https://github.com/axios/axios) to make a `GET` request against the source URL of the image. The response body will contain the image itself, which can be written to a file using [fs](https://nodejs.org/api/fs.html).
 
@@ -86,14 +70,10 @@ Once we start scraping more information, we might want to have it stored in a st
 
 The code for that could look like this:
 
-{{< tabs "5" >}}
-{{< tab "Playwright" >}}
 ```js
-{{< readfile filename="samples/playwright/basic-get-data-json.js" >}}
+{{% readfile filename="samples/playwright/basic-get-data-json.js" %}}
 ```
 {{< run-in-checkly "/samples/playwright/basic-get-data-json.js" "playwright"  >}}
-{{< /tab >}}
-{{< /tabs >}}
 
 The resulting `books.json` file will look like the following:
 

--- a/site/layouts/shortcodes/readfile.html
+++ b/site/layouts/shortcodes/readfile.html
@@ -1,2 +1,2 @@
-{{ $filename := .Get "filename" }}
-{{ readFile $filename | safeHTML }}
+{{- $filename := .Get "filename" -}}
+{{- readFile $filename | safeHTML -}}

--- a/src/scss/_learn.scss
+++ b/src/scss/_learn.scss
@@ -664,7 +664,7 @@
 
 .run-in-checkly {
   position: absolute;
-  bottom: 47px;
+  translate: -20px -70px;
   background-color: #0075ff;
   z-index: 100000000;
   right: 22px;
@@ -674,6 +674,10 @@
   padding: 5px 10px;
   border-radius: 4px;
   font-size: 14px;
+
+  @include media-breakpoint-down(md) {
+    translate: 10px -70px;
+  }
 }
 
 .learn-cta-wrapper {


### PR DESCRIPTION
## Affected Components
* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [ ] Docs
* [x] Learn
* [ ] Other

## Pre-Requisites
* [ ] Code is linted (`npm run lint`)

## Notes for the Reviewer
- removes the unneeded, left over Playwright tabs / tab scructure
- updates the `readFile` and related "run in Checkly" code to reflect new situation.

### Screenshots

no more tabs + correctly aligned "run in checkly button"

desktop: 

![CleanShot 2024-11-06 at 14 25 19](https://github.com/user-attachments/assets/20673e23-34f9-4cb8-88bb-4ab39e5e85fd)

mobile:

![CleanShot 2024-11-06 at 14 26 28](https://github.com/user-attachments/assets/ad99b678-1449-4b8e-bddc-ec86c25a72a9)

