### PR TITLE
fix: learn breadcrumb and head partial  [sc-00]

### DIFF
--- a/site/layouts/_default/baseof.html
+++ b/site/layouts/_default/baseof.html
@@ -8,8 +8,9 @@
 {{ else if .Params.heroDescription }}
   {{ .Scratch.Set "subtitle_text" .Params.heroDescription }}
 {{ end }}
-{{ partial "head" . }}
-
+<head>
+  {{ partial "head" . }}
+</head>
 <body>
   {{ block "main" . }}
   {{ end }}

--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -1,8 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 {{ .Scratch.Set "template_name" "site" }}
-{{ partial "head" . }}
-
+<head>
+  {{ partial "head" . }}
+</head>
 <body class="landing">
   <div class="main">
     <div style="padding: 2rem; text-align: center; max-width: 50ch; margin: 2rem auto;">

--- a/site/layouts/partials/head.html
+++ b/site/layouts/partials/head.html
@@ -1,6 +1,4 @@
-<head>
-   
-  <title>{{ if .Params.title }}{{ .Params.title }}{{ else }}{{ .Site.Title }}{{ end }}</title>
+ <title>{{ if .Params.title }}{{ .Params.title }}{{ else }}{{ .Site.Title }}{{ end }}</title>
 
   <meta charset="utf-8" />
   <meta name="description" content="{{ with .Description }}{{ . | markdownify }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . | markdownify}}{{ end }}{{ end }}{{ end }}" />
@@ -96,4 +94,3 @@
       a.appendChild(r);
     })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
   </script>
-</head>

--- a/site/layouts/partials/learn-breadcrumb.html
+++ b/site/layouts/partials/learn-breadcrumb.html
@@ -5,13 +5,17 @@
   {{ range $index, $element := split $url "/" }}
     {{ $.Scratch.Add "path" $element }}
     {{ if ne $element "" }}
-
       {{ if ne $element "learn" }}
-        {{ if eq $index 3 }}
-          <a href="/learn/playwright/">Playwright Automation Guide</a>
+        {{ if eq $index 2 }}
+            {{ if eq $element "playwright" }}
+              <a href="/learn/playwright/">Playwright Automation Guide</a>
+            {{ end }}
+            {{ if eq $element "opentelemetry" }}
+              <a href="/learn/playwright/">Open Telemetry Guide</a>
+            {{ end }}
         {{ else }}
           <span>/</span>
-          {{ if eq $index 3 }}
+          {{ if eq $index 2 }}
             <a href="/learn/{{ . }}/">{{ humanize . }}</a>
           {{ else }}
             {{ humanize . }}


### PR DESCRIPTION
## Affected Components
* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [ ] Docs
* [x] Learn
* [x] Other

## Pre-Requisites
* [ ] Code is linted (`npm run lint`)

## Notes for the Reviewer
- Learn section has breadcrumb that mentions "open telemetry" in otel section
- fixes double <head> nesting
