### PR TITLE
fix: remove /tags from sitemap [sc-00]

### DIFF
--- a/site/content/docs/traces-open-telemetry/importing-traces/troubleshooting-missing-spans.md
+++ b/site/content/docs/traces-open-telemetry/importing-traces/troubleshooting-missing-spans.md
@@ -57,7 +57,7 @@ Missing spans can happen due to various reasons. Whether you're sending data to 
       ```
 
    #### Sampling directly in your applications' code. 
-   Choose the specific [instrumentation language guide](docs/traces-open-telemetry/instrumenting-code/) and review your configuration against Step 2 in the guides.
+   Choose the specific [instrumentation language guide](/docs/traces-open-telemetry/instrumenting-code/) and review your configuration against Step 2 in the guides.
 
 ### Review OpenTelemetry Exporter configuration
   
@@ -94,7 +94,7 @@ Ensure the right Authorization keys and endpoints are in use.
    ```
 
 ### Checkly Private Location setup
-   When setting up Traces with a [Checkly Private Location](docs/private-locations/#configuring-a-private-location):
+   When setting up Traces with a [Checkly Private Location](/docs/private-locations/#configuring-a-private-location):
   * **Step 1**. Ensure your [Checkly Agent](https://hub.docker.com/r/checkly/agent) version is at least 3.3.5.
   
   * **Step 2**. Review your internal Firewall rules: 
@@ -113,5 +113,5 @@ Ensure the right Authorization keys and endpoints are in use.
 
 ### Incomplete instrumentation
    
-   To see the full picture, and identify the root cause of a problem faster, ensure your applications and services are [instrumented with the OpenTelemetry SDK](docs/traces-open-telemetry/instrumenting-code/).
+   To see the full picture, and identify the root cause of a problem faster, ensure your applications and services are [instrumented with the OpenTelemetry SDK](/docs/traces-open-telemetry/instrumenting-code/).
     

--- a/site/layouts/_default/sitemap.xml
+++ b/site/layouts/_default/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
   {{ range .Data.Pages }}
-  {{-     if or (eq (isset .Params "sitemapexclude") false) (ne .Params.sitemapExclude true) }}
+  {{- if and (or (eq (isset .Params "sitemapexclude") false) (ne .Params.sitemapExclude true)) (ne .Kind "taxonomy") (ne .Kind "term") }}
   <url>
     <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
     <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
@@ -19,6 +19,6 @@
                 href="{{ .Permalink }}"
                 />{{ end }}
   </url>
-  {{-     end }}
+  {{- end }}
   {{ end }}
 </urlset>


### PR DESCRIPTION
## Affected Components
* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [ ] Docs
* [ ] Learn
* [ ] Other

## Pre-Requisites
* [ ] Code is linted (`npm run lint`)

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->
Our sitemap has some /tags pages autogenerated by Hugo and thats not good for SEO. This change was requested by Growtika https://trello.com/c/EhuEAL6H/207-november-404-tag-pages-in-sitemap
