### PR TITLE
add missing }, thanks Mark!

### DIFF
--- a/site/content/docs/traces-open-telemetry/instrumenting-code/nextjs.md
+++ b/site/content/docs/traces-open-telemetry/instrumenting-code/nextjs.md
@@ -80,6 +80,7 @@ export function register() {
       },
     },
   })
+}
 ```
 
 Notice that we are using the default exporter and span processor from the `@vercel/otel` package, which is configured by using the `auto` value.


### PR DESCRIPTION
## Affected Components
* [x] Docs

## Notes for the Reviewer
We were missing a closing } so it didn't work when copy-pasting