### PR TITLE
Fix header formatting on test in parallel page

### DIFF
--- a/site/content/learn/playwright/testing-in-parallel.md
+++ b/site/content/learn/playwright/testing-in-parallel.md
@@ -44,10 +44,10 @@ Alternatively, for more granular control, you can use the test.describe.configur
 ## Running Tests in Sequence
 While parallel execution is efficient, certain scenarios necessitate running tests sequentially. This is especially true for destructive tests, where ensuring a predictable and unaltered environment state is crucial for test accuracy.
 
-###Sequential Execution by Default
+### Sequential Execution by Default
 By default, Playwright treats the order of test cases within a spec file as sequential. If your tests are organized within a single file, Playwright will execute them one after another, using a single worker.
 
-###Enforcing Sequential Execution
+### Enforcing Sequential Execution
 For projects with tests spread across multiple files, achieving sequential execution requires a bit more configuration. You can limit Playwright to use a single worker globally via the Playwright configuration file or on a per-directory basis using the command line.
 
 ```ts {title="playwright.config.ts"}


### PR DESCRIPTION
## Affected Components
* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [ ] Docs
* [x] Learn
* [ ] Other

## Pre-Requisites
* [ ] Code is linted (`npm run lint`)

Before:
<img width="740" alt="Screenshot 2024-12-05 at 16 42 39" src="https://github.com/user-attachments/assets/544b9f41-9c20-4e38-8ab8-e12da1181f02">

After:
<img width="805" alt="Screenshot 2024-12-05 at 16 43 02" src="https://github.com/user-attachments/assets/4c61f5be-0a55-4ceb-ae5a-31a1213f9c30">
