### PR TITLE
feat: restructures all learn content into three menus. Adds new gener…

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -31,7 +31,7 @@ disqusShortname = "checkly"
     weight = 20
 [[menu.topnav]]
     name = "Learn"
-    url = "/learn/playwright/"
+    url = "/learn/"
     weight = 30
 [[menu.topnav]]
     name = "API Reference"
@@ -170,47 +170,46 @@ disqusShortname = "checkly"
     url = "https://developers.checklyhq.com"
     weight = 200
 
-[[menu.learn]]
-	name = "Getting started"
-	pre = "/learn/icons/playwright-logo.svg"
-	weight = 300
-
-[[menu.learn]]
+[[menu.learn_playwright]]
 	name = "Basics"
 	pre = "/learn/icons/misc.svg"
 	weight = 310
 
-[[menu.learn]]
+[[menu.learn_playwright]]
 	name = "Interaction"
 	pre = "/learn/icons/pages.svg"
 	weight = 320
 
-[[menu.learn]]
+[[menu.learn_playwright]]
+	name = "Getting started"
+	pre = "/learn/icons/playwright-logo.svg"
+	weight = 300
+
+[[menu.learn_playwright]]
+	name = "Basics"
+	pre = "/learn/icons/misc.svg"
+	weight = 310
+
+[[menu.learn_playwright]]
+	name = "Interaction"
+	pre = "/learn/icons/pages.svg"
+	weight = 320
+
+[[menu.learn_playwright]]
 	name = "Best practices"
 	pre = "/learn/icons/best-practices.svg"
 	weight = 330
 
-[[menu.learn]]
+[[menu.learn_playwright]]
 	name = "E2E examples"
 	pre = "/learn/icons/e2e.svg"
 	weight = 340
 
 
-[[menu.learn]]
+[[menu.learn_playwright]]
 	name = "Debugging"
 	pre = "/learn/icons/errors.svg"
 	weight = 350
-
-[[menu.learn]]
-	name = "OpenTelemetry"
-	pre = "/learn/icons/opentelemetry-logo.svg"
-	weight = 360
-
-
-[[menu.learn]]
-	name = "Kubernetes"
-	pre = "/learn/icons/kubernetes-logo.svg"
-	weight = 380
 
 
 [markup.goldmark.renderer]

--- a/site/content/learn/_index.md
+++ b/site/content/learn/_index.md
@@ -6,21 +6,13 @@ displayDescription:
   Learn more about Playwright & Monitoring with Checkly. Explore how to automate your web with a reliable, programmable monitoring workflow.
 metatags:
   title: Learn Playwright & Checkly - Browser Automation
-
+layout: learn-home
 ---
 
 Monitoring and Observability are key concepts when dealing with application quality and performance. Learn the fundamentals of modern monitoring and observability to help yourself and your team build better applications.
 ## Getting Started
 
 <div class="cards-list">
-{{< doc-card
-	  class="three-column-card"
-	  headerTag="h3"
-	  title="Monitoring"
-	  img="/learn/icons/checkly-logo-light-mode-square.svg"
-	  description="Learn how to monitor your application with Checkly."
-	  link="/guides/monitoring-as-code/"
->}}
 {{< doc-card
 	  class="three-column-card"
 	  headerTag="h3"
@@ -35,7 +27,15 @@ Monitoring and Observability are key concepts when dealing with application qual
 	  title="Open Telemetry"
 	  img="/learn/icons/opentelemetry-logo.svg"
 	  description="Learn how to instrument your application with OTel and get deep insights into your full stack."
-	  link="/learn/opentelemetry/getting-started-with-observability/"
+	  link="/learn/opentelemetry/"
+>}}
+{{< doc-card
+	  class="three-column-card"
+	  headerTag="h3"
+	  title="Kubernetes"
+	  img="/learn/icons/kubernetes-logo.svg"
+	  description="Learn basics, tools and tips for monitoring your Kubernetes clusters."
+	  link="/learn/kubernetes"
 >}}
 </div>
 

--- a/site/content/learn/kubernetes/_index.md
+++ b/site/content/learn/kubernetes/_index.md
@@ -1,0 +1,51 @@
+---
+title: Learn How to Observe and Monitor your Kubernetes
+displayTitle: Monitoring Kubernetes
+description: Learn OpenTelemetry with Checkly. Add monitoring to every piece of your stack with the open standards and open-source tools.
+date: 2024-10-17
+author: Nocnica Mellifera
+githubUser: serverless-mom
+displayDescription:
+---
+
+Learn about monitoring Kubernetes.
+
+## Getting Started
+
+<div class="cards-list">
+{{< doc-card
+	  class="two-column-card"
+	  headerTag="h3"
+	  title="Getting started."
+	  img="/learn/icons/kubernetes-logo.svg"
+	  description="Learn the basics of monitoring your Kubernetes cluster."
+	  link="/learn/kubernetes/monitoring-challenges/"
+>}}
+{{< doc-card
+	  class="two-column-card"
+	  headerTag="h3"
+	  title="Learn about logging best practices."
+	  img="/learn/icons/kubernetes-logo.svg"
+	  description="Learn how to instrument your application and get deep insights into your stack."
+	  link="/learn/kubernetes/logging-best-practices/"
+>}}
+</div>
+
+## Diving Deeper
+
+<div class="cards-list">
+{{< doc-card
+	class="two-column-card"
+	headerTag="h3"
+	title="Metrics"
+	description="Learn about Kubernetes key metrics and how to use them for monitoring."
+	link="/learn/kubernetes/monitoring-metrics/"
+>}}
+{{< doc-card
+	class="two-column-card"
+	headerTag="h3"
+	title="Events"
+	description="Learn about key events of the Kubernetes lifecycle."
+	link="/learn/kubernetes/events/"
+>}}
+</div>

--- a/site/content/learn/kubernetes/centralized-logging.md
+++ b/site/content/learn/kubernetes/centralized-logging.md
@@ -9,8 +9,7 @@ githubUser: serverless-mom
 displayDescription: 
   Learn about using OpenTelemetry for centralized logging in Kubernetes
 menu:
-  learn:
-    parent: "Kubernetes"
+  learn_kubernetes
 weight: 30
 ---
 Monitoring logs effectively in a Kubernetes environment requires tools that centralize and streamline log management. With OpenTelemetry, Kubernetes administrators can collect, process, and export logs from applications and infrastructure, ensuring consistent data and reducing the need for multiple, disparate logging solutions. Here’s an overview of how OpenTelemetry supports centralized logging in Kubernetes and the practical benefits it offers.

--- a/site/content/learn/kubernetes/events.md
+++ b/site/content/learn/kubernetes/events.md
@@ -9,8 +9,7 @@ githubUser: serverless-mom
 displayDescription: How events can help you explore change of state on your cluster
 
 menu:
-  learn:
-    parent: "Kubernetes"
+  learn_kubernetes
 weight: 65
 ---
 

--- a/site/content/learn/kubernetes/klog.md
+++ b/site/content/learn/kubernetes/klog.md
@@ -9,8 +9,7 @@ githubUser: serverless-mom
 displayDescription: klog, a permanent fork of glog, is a go logging tool focused on structured logging in a Kubernetes envrionment.
 
 menu:
-  learn:
-    parent: "Kubernetes"
+  learn_kubernetes
 weight: 60
 ---
 

--- a/site/content/learn/kubernetes/logging-best-practices.md
+++ b/site/content/learn/kubernetes/logging-best-practices.md
@@ -9,8 +9,7 @@ githubUser: serverless-mom
 displayDescription: 
   Best practices for logging in your Kubernetes-hosted applications and infrastructure.
 menu:
-  learn:
-    parent: "Kubernetes"
+  learn_kubernetes
 weight: 20
 ---
 Logging in Kubernetes can be a challenge, especially when dealing with data across a distributed, containerized system. To keep your logs efficient and actionable, it's essential to understand logging best practices, from handling diverse formats to managing back pressure effectively. Here are the best practices for Kubernetes logging, focused on tools, performance, and scalability.

--- a/site/content/learn/kubernetes/monitoring-challenges.md
+++ b/site/content/learn/kubernetes/monitoring-challenges.md
@@ -9,8 +9,7 @@ githubUser: serverless-mom
 displayDescription: 
   We explore the unique challenges of monitoring Kubernetes environments and the open-source tools that can improve visibility and control.
 menu:
-  learn:
-    parent: "Kubernetes"
+  learn_kubernetes
 weight: 1
 ---
 Managing Kubernetes in production is no small feat, especially when it comes to monitoring and observability. As modern applications grow in complexity, traditional methods of monitoring, limited to CPU and memory usage, often fall short. In this article, we explore the unique challenges of monitoring Kubernetes environments and the open-source tools that can improve visibility and control.

--- a/site/content/learn/kubernetes/monitoring-metrics.md
+++ b/site/content/learn/kubernetes/monitoring-metrics.md
@@ -9,8 +9,7 @@ githubUser: serverless-mom
 displayDescription: 
   A comprehensive overview of the key metrics to monitor in a Kubernetes environment and the challenges associated with monitoring in such a complex infrastructure.
 menu:
-  learn:
-    parent: "Kubernetes"
+  learn_kubernetes
 weight: 60
 ---
 

--- a/site/content/learn/kubernetes/node-problem-detector.md
+++ b/site/content/learn/kubernetes/node-problem-detector.md
@@ -9,8 +9,7 @@ githubUser: serverless-mom
 displayDescription: Find unhealthy nodes with the Node Problem Detector
 
 menu:
-  learn:
-    parent: "Kubernetes"
+  learn_kubernetes
 weight: 80
 ---
 

--- a/site/content/learn/kubernetes/operators-metrics.md
+++ b/site/content/learn/kubernetes/operators-metrics.md
@@ -9,8 +9,7 @@ githubUser: serverless-mom
 displayDescription: How to create a first Kubernetes operator, and monitor the operator state with Prometheus.
 
 menu:
-  learn:
-    parent: "Kubernetes"
+  learn_kubernetes
 weight: 70
 ---
 

--- a/site/content/learn/kubernetes/structured-logging.md
+++ b/site/content/learn/kubernetes/structured-logging.md
@@ -9,8 +9,7 @@ githubUser: serverless-mom
 displayDescription: 
   Best practices for structured logging.
 menu:
-  learn:
-    parent: "Kubernetes"
+   learn_kubernetes
 weight: 50
 ---
 

--- a/site/content/learn/opentelemetry/_index.md
+++ b/site/content/learn/opentelemetry/_index.md
@@ -1,0 +1,53 @@
+---
+title: Learn How to Observe and Monitor your Software with OpenTelemetry
+displayTitle: Getting started with OpenTelemetry and Observability
+navTitle: What is Observability?
+description: Learn OpenTelemetry with Checkly. Add monitoring to every piece of your stack with the open standards and open-source tools.
+date: 2024-10-17
+author: Nocnica Mellifera
+githubUser: serverless-mom
+displayDescription:
+---
+
+Learn Observability and OpenTelemetry with Checkly. Add monitoring to every piece of your stack with the open standards 
+and open-source tools.
+
+## Getting Started
+
+<div class="cards-list">
+{{< doc-card
+	  class="two-column-card"
+	  headerTag="h3"
+	  title="Getting started with Observability"
+	  img="/learn/icons/opentelemetry-logo.svg"
+	  description="Learn the basics of observability and how to get started with OpenTelemetry."
+	  link="/learn/opentelemetry/getting-started-with-observability/"
+>}}
+{{< doc-card
+	  class="two-column-card"
+	  headerTag="h3"
+	  title="How to instrument your application stack."
+	  img="/learn/icons/opentelemetry-logo.svg"
+	  description="Learn how to instrument your application and get deep insights into your stack."
+	  link="/learn/opentelemetry/how-to-instrument/"
+>}}
+</div>
+
+## Diving Deeper
+
+<div class="cards-list">
+{{< doc-card
+	class="two-column-card"
+	headerTag="h3"
+	title="Metrics"
+	description="Learn about metrics and how to use them to monitor your application."
+	link="/learn/opentelemetry/metrics/"
+>}}
+{{< doc-card
+	class="two-column-card"
+	headerTag="h3"
+	title="Traces"
+	description="Learn about tracing and its importance in monitoring your application."
+	link="/learn/opentelemetry/traces/"
+>}}
+</div>

--- a/site/content/learn/opentelemetry/getting-started-with-observability.md
+++ b/site/content/learn/opentelemetry/getting-started-with-observability.md
@@ -1,5 +1,5 @@
 ---
-title: Learn How to Observe and Monitor your Software with OpenTelemetry
+title: Getting Started with Observability
 displayTitle: Getting started with Observability
 navTitle: What is Observability?
 description: Learn OpenTelemetry with Checkly. Add monitoring to every piece of your stack with the open standards and open-source tools.
@@ -8,8 +8,7 @@ author: Nocnica Mellifera
 githubUser: serverless-mom
 displayDescription: 
 menu:
-  opentelemetry:
-    parent: "Basics"
+  learn_opentelemetry
 weight: 1
 ---
 

--- a/site/content/learn/opentelemetry/how-to-instrument.md
+++ b/site/content/learn/opentelemetry/how-to-instrument.md
@@ -10,8 +10,7 @@ githubUser: serverless-mom
 displayDescription: 
   OpenTelemetry offers two main strategies for adding observability to your application, learn how they work together
 menu:
-  learn:
-    parent: "OpenTelemetry"
+  learn_opentelemetry
 weight: 2
 ---
 

--- a/site/content/learn/opentelemetry/metrics.md
+++ b/site/content/learn/opentelemetry/metrics.md
@@ -9,8 +9,7 @@ githubUser: serverless-mom
 displayDescription: 
   Learn more about OpenTelemetry & Monitoring with Checkly. Explore metrics, one of the three pillars of observability.
 menu:
-  learn:
-    parent: "OpenTelemetry"
+  learn_opentelemetry
 weight: 3
 ---
 **OpenTelemetry Metrics** play a critical role in monitoring applications by offering a way to capture and analyze key metrics in a standardized, scalable manner. Whether you're managing a complex microservices architecture or a simpler system, OpenTelemetry helps track essential statistics that reveal the health and performance of your services.

--- a/site/content/learn/opentelemetry/otel-agent-management-protocol.md
+++ b/site/content/learn/opentelemetry/otel-agent-management-protocol.md
@@ -9,8 +9,7 @@ githubUser: serverless-mom
 displayDescription: 
   The OpenTelemetry Open Agent Management Protocol (OpAMP) is an emerging standard aimed at managing telemetry agents, such as the OpenTelemetry Collector, at scale.
 menu:
-  learn:
-    parent: "OpenTelemetry"
+  learn_opentelemetry
 weight: 10
 ---
 ## An introduction to OpenTelemetry's new project to allow control of collectors at scale

--- a/site/content/learn/opentelemetry/otel-filtering.md
+++ b/site/content/learn/opentelemetry/otel-filtering.md
@@ -10,8 +10,7 @@ githubUser: serverless-mom
 displayDescription: 
   An advanced guide to filtering data with processors and the OpenTelemetry Transform Language
 menu:
-  learn:
-    parent: "OpenTelemetry"
+  learn_opentelemetry
 weight: 7
 ---
 

--- a/site/content/learn/opentelemetry/trace-api.md
+++ b/site/content/learn/opentelemetry/trace-api.md
@@ -9,8 +9,7 @@ githubUser: serverless-mom
 displayDescription: 
   The OpenTelemetry Trace API provides developers with the tools needed to create, manage, and analyze traces, a critical component of observability.
 menu:
-  learn:
-    parent: "OpenTelemetry"
+  learn_opentelemetry
 weight: 9
 ---
 ## Taking direct control of OpenTelemetry traces via the API

--- a/site/content/learn/opentelemetry/traces.md
+++ b/site/content/learn/opentelemetry/traces.md
@@ -9,12 +9,9 @@ githubUser: serverless-mom
 displayDescription: 
   Learn more about OpenTelemetry & Monitoring with Checkly. Explore metrics, one of the three pillars of observability.
 menu:
-  learn:
-    parent: "OpenTelemetry"
+   learn_opentelemetry
 weight: 4
 ---
-
-# An Introduction to OpenTelemetry Traces
 
 ## What Are OpenTelemetry Traces?
 

--- a/site/content/learn/opentelemetry/what-is-the-otel-collector.md
+++ b/site/content/learn/opentelemetry/what-is-the-otel-collector.md
@@ -10,8 +10,7 @@ githubUser: serverless-mom
 displayDescription: 
   Learn more about Playwright & Monitoring with Checkly. Explore how to automate your web with a reliable, programmable monitoring workflow.
 menu:
-  learn:
-    parent: "OpenTelemetry"
+   learn_opentelemetry
 weight: 5
 ---
 

--- a/site/content/learn/playwright/assertions.md
+++ b/site/content/learn/playwright/assertions.md
@@ -15,7 +15,7 @@ tags:
 weight: 5
 navTitle: Assertions
 menu:
-  learn:
+  learn_playwright:
     parent: "Interaction"
 ---
 

--- a/site/content/learn/playwright/bypass-totp.md
+++ b/site/content/learn/playwright/bypass-totp.md
@@ -10,7 +10,7 @@ tags:
 weight: 5
 navTitle: TOTP Authentication
 menu:
-  learn:
+  learn_playwright:
     parent: "E2E examples"
 ---
 Testing applications behind a login flow is cumbersome. And it gets even worse when there’s two-factor authentication (2FA)  involved. Many people work around this problem by disabling it or implementing wild hacks.

--- a/site/content/learn/playwright/challenging-flows.md
+++ b/site/content/learn/playwright/challenging-flows.md
@@ -9,7 +9,7 @@ tags:
 weight: 4
 navTitle: Complex workflows
 menu:
-  learn:
+  learn_playwright:
     parent: "Best practices"
 ---
 

--- a/site/content/learn/playwright/checkout-testing-guide.md
+++ b/site/content/learn/playwright/checkout-testing-guide.md
@@ -9,7 +9,7 @@ tags:
 weight: 1
 navTitle: Checkout
 menu:
-  learn:
+  learn_playwright:
     parent: "E2E examples"
 ---
 

--- a/site/content/learn/playwright/clicking-typing-hovering.md
+++ b/site/content/learn/playwright/clicking-typing-hovering.md
@@ -14,7 +14,7 @@ tags:
 weight: 2
 navTitle: Clicking and typing
 menu:
-  learn:
+  learn_playwright:
     parent: "Interaction"
 ---
 

--- a/site/content/learn/playwright/debugging-errors.md
+++ b/site/content/learn/playwright/debugging-errors.md
@@ -11,7 +11,7 @@ weight: 2
 navTitle: Common issues
 
 menu:
-  learn:
+  learn_playwright:
     parent: "Debugging"
 ---
 

--- a/site/content/learn/playwright/debugging.md
+++ b/site/content/learn/playwright/debugging.md
@@ -11,7 +11,7 @@ weight: 1
 navTitle: Debugging scripts
 
 menu:
-  learn:
+  learn_playwright:
     parent: "Debugging"
 ---
 

--- a/site/content/learn/playwright/emulating-mobile-devices.md
+++ b/site/content/learn/playwright/emulating-mobile-devices.md
@@ -14,7 +14,7 @@ navTitle: Emulating mobile devices
 weight: 5
 
 menu:
-  learn:
+  learn_playwright:
     parent: "Basics"
 ---
 

--- a/site/content/learn/playwright/error-click-not-executed.md
+++ b/site/content/learn/playwright/error-click-not-executed.md
@@ -8,7 +8,7 @@ tags:
 weight: 3
 navTitle: Click not executed
 menu:
-  learn:
+  learn_playwright:
     parent: "Debugging"
 ---
 

--- a/site/content/learn/playwright/error-element-not-found.md
+++ b/site/content/learn/playwright/error-element-not-found.md
@@ -8,7 +8,7 @@ tags:
 weight: 4
 navTitle: Element not found
 menu:
-  learn:
+  learn_playwright:
     parent: "Debugging"
 ---
 

--- a/site/content/learn/playwright/error-element-not-visible.md
+++ b/site/content/learn/playwright/error-element-not-visible.md
@@ -8,7 +8,7 @@ tags:
 weight: 5
 navTitle: Element not visible
 menu:
-  learn:
+  learn_playwright:
     parent: "Debugging"
 ---
 

--- a/site/content/learn/playwright/error-target-closed.md
+++ b/site/content/learn/playwright/error-target-closed.md
@@ -8,7 +8,7 @@ tags:
 weight: 6
 navTitle: Target closed
 menu:
-  learn:
+  learn_playwright:
     parent: "Debugging"
 ---
 

--- a/site/content/learn/playwright/error-wait-not-respected.md
+++ b/site/content/learn/playwright/error-wait-not-respected.md
@@ -8,7 +8,7 @@ tags:
 weight: 7
 navTitle: Wait not respected
 menu:
-  learn:
+  learn_playwright:
     parent: "Debugging"
 ---
 

--- a/site/content/learn/playwright/file-download.md
+++ b/site/content/learn/playwright/file-download.md
@@ -10,7 +10,7 @@ tags:
 navTitle: Downloading files
 weight: 4
 menu:
-  learn:
+  learn_playwright:
     parent: "E2E examples"
 ---
 

--- a/site/content/learn/playwright/generating-pdfs.md
+++ b/site/content/learn/playwright/generating-pdfs.md
@@ -9,7 +9,7 @@ tags:
 weight: 2
 navTitle: Generating PDFs
 menu:
-  learn:
+  learn_playwright:
     parent: "Basics"
 ---
 

--- a/site/content/learn/playwright/google-login-automation.md
+++ b/site/content/learn/playwright/google-login-automation.md
@@ -10,7 +10,7 @@ tags:
 navTitle: Google Auth
 weight: 9
 menu:
-  learn:
+  learn_playwright:
     parent: "E2E examples"
 ---
 

--- a/site/content/learn/playwright/handling-test-data.md
+++ b/site/content/learn/playwright/handling-test-data.md
@@ -10,7 +10,7 @@ tags:
 weight: 3
 navTitle: Test data
 menu:
-  learn:
+  learn_playwright:
     parent: "Best practices"
 ---
 

--- a/site/content/learn/playwright/how-to-detect-broken-links.md
+++ b/site/content/learn/playwright/how-to-detect-broken-links.md
@@ -10,7 +10,7 @@ tags:
 weight: 3
 navTitle: Detecting broken links
 menu:
-  learn:
+  learn_playwright:
     parent: "Basics"
 ---
 

--- a/site/content/learn/playwright/how-to-parameterize-playwright-projects.md
+++ b/site/content/learn/playwright/how-to-parameterize-playwright-projects.md
@@ -10,7 +10,7 @@ tags:
 weight: 3
 navTitle: Parameterizing Projects
 menu:
-  learn:
+  learn_playwright:
     parent: "Best practices"
 ---
 

--- a/site/content/learn/playwright/how-to-search.md
+++ b/site/content/learn/playwright/how-to-search.md
@@ -11,7 +11,7 @@ tags:
 navTitle: Search
 weight: 5
 menu:
-  learn:
+  learn_playwright:
     parent: "E2E examples"
 ---
 

--- a/site/content/learn/playwright/how-to-set-up-locally.md
+++ b/site/content/learn/playwright/how-to-set-up-locally.md
@@ -9,7 +9,7 @@ weight: 2
 displayTitle: How to Set Up Playwright Locally
 navTitle: Setting up Playwright
 menu:
-  learn:
+  learn_playwright:
     parent: "Getting started"
 ---
 

--- a/site/content/learn/playwright/iframe-interaction.md
+++ b/site/content/learn/playwright/iframe-interaction.md
@@ -9,7 +9,7 @@ tags:
 weight: 6
 navTitle: Interacting with iframes
 menu:
-  learn:
+  learn_playwright:
     parent: "Interaction"
 ---
 

--- a/site/content/learn/playwright/intercept-requests.md
+++ b/site/content/learn/playwright/intercept-requests.md
@@ -13,7 +13,7 @@ tags:
 weight: 4
 navTitle: Intercepting requests
 menu:
-  learn:
+  learn_playwright:
     parent: "Basics"
 ---
 

--- a/site/content/learn/playwright/login-automation.md
+++ b/site/content/learn/playwright/login-automation.md
@@ -10,7 +10,7 @@ tags:
 navTitle: Standard authentication
 weight: 7
 menu:
-  learn:
+  learn_playwright:
     parent: "E2E examples"
 ---
 

--- a/site/content/learn/playwright/managing-cookies.md
+++ b/site/content/learn/playwright/managing-cookies.md
@@ -9,7 +9,7 @@ tags:
 weight: 3
 navTitle: Managing cookies & state
 menu:
-  learn:
+  learn_playwright:
     parent: Basics
 category: Playwright
 ---

--- a/site/content/learn/playwright/microsoft-login-automation.md
+++ b/site/content/learn/playwright/microsoft-login-automation.md
@@ -10,7 +10,7 @@ tags:
 navTitle: Microsoft Live Auth
 weight: 8
 menu:
-  learn:
+  learn_playwright:
     parent: "E2E examples"
 ---
 

--- a/site/content/learn/playwright/multitab-flows.md
+++ b/site/content/learn/playwright/multitab-flows.md
@@ -10,7 +10,7 @@ tags:
 weight: 6
 navTitle: Multiple tabs
 menu:
-  learn:
+  learn_playwright:
     parent: "Basics"
 ---
 

--- a/site/content/learn/playwright/navigation.md
+++ b/site/content/learn/playwright/navigation.md
@@ -15,7 +15,7 @@ tags:
 weight: 1
 navTitle: Navigation
 menu:
-  learn:
+  learn_playwright:
     parent: "Interaction"
 ---
 

--- a/site/content/learn/playwright/performance.md
+++ b/site/content/learn/playwright/performance.md
@@ -11,7 +11,7 @@ tags:
 weight: 1
 navTitle: Performance
 menu:
-  learn:
+  learn_playwright:
     parent: "Best practices"
 ---
 

--- a/site/content/learn/playwright/playwright-vs-cypress.md
+++ b/site/content/learn/playwright/playwright-vs-cypress.md
@@ -11,7 +11,7 @@ weight: 4
 displayTitle: Playwright vs Cypress
 navTitle: Playwright vs Cypress
 menu:
-  learn:
+  learn_playwright:
     parent: "Getting started"
 ---
 Playwright and Cypress are two frameworks both closely associated with end-to-end testing of production websites. Both frameworks can do quite a bit more than 'making sure nothing on your site is broken' and their design philosophies, architectures, and use cases are different.

--- a/site/content/learn/playwright/playwright-vs-others.md
+++ b/site/content/learn/playwright/playwright-vs-others.md
@@ -11,7 +11,7 @@ tags:
 weight: 3
 
 menu:
-  learn:
+  learn_playwright:
     parent: "Getting started"
 ---
 There are a number of options when for [frameworks for end-to-end testing](https://www.checklyhq.com/blog/cypress-vs-selenium-vs-playwright-vs-puppeteer-speed-comparison/). If you're thinking about using Checkly, you're likely aware of a few.

--- a/site/content/learn/playwright/playwright-vs-selenium.md
+++ b/site/content/learn/playwright/playwright-vs-selenium.md
@@ -11,7 +11,7 @@ weight: 5
 displayTitle: Playwright vs Selenium
 navTitle: Playwright vs Selenium
 menu:
-  learn:
+  learn_playwright:
     parent: "Getting started"
 ---
 

--- a/site/content/learn/playwright/scraping-behind-login.md
+++ b/site/content/learn/playwright/scraping-behind-login.md
@@ -9,7 +9,7 @@ tags:
 weight: 6
 navTitle: Scraping behind a login
 menu:
-  learn:
+  learn_playwright:
     parent: "Best practices"
 ---
 

--- a/site/content/learn/playwright/script-recorders.md
+++ b/site/content/learn/playwright/script-recorders.md
@@ -9,7 +9,7 @@ tags:
 weight: 7
 navTitle: Script recorders
 menu:
-  learn:
+  learn_playwright:
     parent: "Best practices"
 ---
 

--- a/site/content/learn/playwright/selectors.md
+++ b/site/content/learn/playwright/selectors.md
@@ -13,7 +13,7 @@ tags:
 weight: 3
 navTitle: UI selectors
 menu:
-  learn:
+  learn_playwright:
     parent: "Interaction"
 ---
 

--- a/site/content/learn/playwright/steps-decorators.md
+++ b/site/content/learn/playwright/steps-decorators.md
@@ -10,7 +10,7 @@ tags:
 weight: 7
 navTitle: Automatic Steps
 menu:
-  learn:
+  learn_playwright:
     parent: "Best practices"
 ---
 You can write Playwright end-to-end testing code using JavaScript or TypeScript. Which one should you choose?

--- a/site/content/learn/playwright/taking-screenshots.md
+++ b/site/content/learn/playwright/taking-screenshots.md
@@ -10,7 +10,7 @@ tags:
 weight: 1
 navTitle: Taking screenshots
 menu:
-  learn:
+  learn_playwright:
     parent: "Basics"
 ---
 

--- a/site/content/learn/playwright/test-fixtures.md
+++ b/site/content/learn/playwright/test-fixtures.md
@@ -12,7 +12,7 @@ tags:
 weight: 7
 navTitle: Test Fixtures
 menu:
-  learn:
+  learn_playwright:
     parent: "Best practices"
 ---
 

--- a/site/content/learn/playwright/testing-apis.md
+++ b/site/content/learn/playwright/testing-apis.md
@@ -10,7 +10,7 @@ tags:
 weight: 3
 navTitle: Testing APIs
 menu:
-  learn:
+  learn_playwright:
     parent: "Best practices"
 ---
 

--- a/site/content/learn/playwright/testing-coupons.md
+++ b/site/content/learn/playwright/testing-coupons.md
@@ -10,7 +10,7 @@ tags:
 weight: 3
 navTitle: Discounts & coupons
 menu:
-  learn:
+  learn_playwright:
     parent: "E2E examples"
 ---
 

--- a/site/content/learn/playwright/testing-file-uploads.md
+++ b/site/content/learn/playwright/testing-file-uploads.md
@@ -12,7 +12,7 @@ weight: 2
 navTitle: File uploads
 
 menu:
-  learn:
+  learn_playwright:
     parent: "E2E examples"
 ---
 

--- a/site/content/learn/playwright/testing-in-parallel.md
+++ b/site/content/learn/playwright/testing-in-parallel.md
@@ -10,7 +10,7 @@ tags:
 weight: 3
 navTitle: Parallel testing
 menu:
-  learn:
+  learn_playwright:
     parent: "Basics"
 ---
 

--- a/site/content/learn/playwright/user-signup-automation.md
+++ b/site/content/learn/playwright/user-signup-automation.md
@@ -10,7 +10,7 @@ tags:
 navTitle: User signup
 weight: 6
 menu:
-  learn:
+  learn_playwright:
     parent: "E2E examples"
 ---
 

--- a/site/content/learn/playwright/waits-and-timeouts.md
+++ b/site/content/learn/playwright/waits-and-timeouts.md
@@ -9,7 +9,7 @@ tags:
 navTitle: Waits and timeouts
 weight: 5
 menu:
-  learn:
+  learn_playwright:
     parent: "Interaction"
 ---
 

--- a/site/content/learn/playwright/web-scraping.md
+++ b/site/content/learn/playwright/web-scraping.md
@@ -12,7 +12,7 @@ tags:
 weight: 5
 navTitle: Scraping
 menu:
-  learn:
+  learn_playwright:
     parent: "Best practices"
 ---
 

--- a/site/content/learn/playwright/what-is-playwright.md
+++ b/site/content/learn/playwright/what-is-playwright.md
@@ -13,7 +13,7 @@ navTitle: What is Playwright?
 aliases:
   - /learn/playwright/getting-started/
 menu:
-  learn:
+  learn_playwright:
     parent: "Getting started"
 ---
 

--- a/site/content/learn/playwright/writing-tests.md
+++ b/site/content/learn/playwright/writing-tests.md
@@ -10,7 +10,7 @@ tags:
 weight: 2
 navTitle: Testing
 menu:
-  learn:
+  learn_playwright:
     parent: "Best practices"
 ---
 

--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -11,7 +11,7 @@
         <img src="/images/racoon_logo.svg" width="80" height="80" alt="checkly logo">
       </div>
       <p style="margin-top: 2rem;">
-        This is the codebase for the Checkly docs and guides. Navigate to <a href="/docs/">/docs</a>, <a href="/guides/">/guides</a> or <a href="/learn/playwright/">/learn</a>.
+        This is the codebase for the Checkly docs and guides. Navigate to <a href="/docs/">/docs</a>, <a href="/guides/">/guides</a> or <a href="/learn/">/learn</a>.
       </p>
     </div>
   </div>

--- a/site/layouts/learn/learn-home.html
+++ b/site/layouts/learn/learn-home.html
@@ -1,0 +1,19 @@
+{{ define "main" }}
+<div class="d-flex container-fluid learn py-5">
+  <div class="learn-page">
+    <article>
+      <h1 class="display-3 w-75">
+        {{ if .Params.displayTitle}}
+        {{.Params.displayTitle}}
+        {{else}}
+        {{.Title}}
+        {{end}}
+      </h1>
+
+      <div class="markdown">
+        {{- .Content -}}
+      </div>
+    </article>
+  </div>
+</div>
+{{end}}

--- a/site/layouts/learn/list.html
+++ b/site/layouts/learn/list.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
 <div class="d-flex container-fluid learn">
-  {{ partial "learn-menu" .}}
+  {{- partial "learn-menu" . -}}
   <div class="learn-page">
     <article class="markdown">
       <div class="d-flex">

--- a/site/layouts/learn/single.html
+++ b/site/layouts/learn/single.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
   <div class="d-flex container-fluid learn">
-    {{ partial "learn-menu" .}}
+    {{- partial "learn-menu" . -}}
     <div class="learn-page">
       <article class="markdown">
         <div class="d-flex">

--- a/site/layouts/partials/docs-menu-walk.html
+++ b/site/layouts/partials/docs-menu-walk.html
@@ -1,8 +1,8 @@
-{{- $page := .page }}
-{{- $menuID := .menuID }}
+{{- $page := .page -}}
+{{- $menuID := .menuID -}}
 
-{{- with index site.Menus $menuID }}
+{{- with index site.Menus $menuID -}}
 <ul class="docs-menu-content">
-  {{- partial "docs-menu-walk-list" (dict "menuID" $menuID "page" $page "menuEntries" .) }}
+  {{- partial "docs-menu-walk-list" (dict "menuID" $menuID "page" $page "menuEntries" .) -}}
 </ul>
-{{- end }}
+{{- end -}}

--- a/site/layouts/partials/learn-breadcrumb.html
+++ b/site/layouts/partials/learn-breadcrumb.html
@@ -1,5 +1,7 @@
 <div class="breadcrumb">
-  {{ $url := replace .Permalink ( printf "%s" .Site.BaseURL) "/" }}
+    <a href="/learn">Learn</a>
+    <span>/</span>
+    {{ $url := replace .Permalink ( printf "%s" .Site.BaseURL) "/" }}
   {{ $.Scratch.Add "path" .Site.BaseURL }}
   {{ $.Scratch.Add "path" "/" }}
   {{ range $index, $element := split $url "/" }}

--- a/site/layouts/partials/learn-breadcrumb.html
+++ b/site/layouts/partials/learn-breadcrumb.html
@@ -11,10 +11,10 @@
               <a href="/learn/playwright/">Playwright Automation Guide</a>
             {{ end }}
             {{ if eq $element "opentelemetry" }}
-              <a href="/learn/playwright/">Open Telemetry Guide</a>
+              <a href="/learn/opentelemetry/">Open Telemetry Guide</a>
             {{ end }}
             {{ if eq $element "kubernetes" }}
-            <a href="/learn/playwright/">Kubernetes Monitoring Guide</a>
+            <a href="/learn/kubernetes/">Kubernetes Monitoring Guide</a>
             {{ end }}
         {{ else }}
           <span>/</span>

--- a/site/layouts/partials/learn-menu-generic.html
+++ b/site/layouts/partials/learn-menu-generic.html
@@ -1,0 +1,25 @@
+{{- $page := .page -}}
+{{- $learnSection := .learnSection -}}
+
+{{- $menuID := print "learn_" $learnSection -}}
+<aside class="learn-menu">
+  <nav id="sideMenu" class="left-transform right-transform">
+    {{- partial "learn-menu-walk" (dict "menuID" $menuID "page" $page) -}}
+  </nav>
+  <div class="learn-menu-mobile-right-space">
+  </div>
+
+  <!-- Restore menu position as soon as possible to avoid flickering -->
+  <script>
+    (function () {
+      const menu = document.querySelector('aside.docs-menu nav')
+      addEventListener('beforeunload', function () {
+        localStorage.setItem('menu.scrollTop', menu.scrollTop)
+      })
+      menu.scrollTop = localStorage.getItem('menu.scrollTop')
+    })()
+  </script>
+
+</aside>
+
+

--- a/site/layouts/partials/learn-menu-walk.html
+++ b/site/layouts/partials/learn-menu-walk.html
@@ -1,0 +1,14 @@
+{{- $page := .page }}
+{{- $menuID := .menuID }}
+
+{{- with index site.Menus $menuID }}
+<ul class="learn-menu-content">
+  {{range $index, $element:= . }} {{ $has := $page.IsMenuCurrent $menuID . }}
+    <li class="learn-menu-sub-item{{if $has}} active{{end}}">
+      <a href="{{.URL}}">
+        {{ partial "learn-title" . }}
+      </a>
+    </li>
+  {{end }}
+</ul>
+{{- end }}

--- a/site/layouts/partials/learn-menu.html
+++ b/site/layouts/partials/learn-menu.html
@@ -1,43 +1,9 @@
-<aside class="learn-menu">
-  <nav id="sideMenu" class="left-transform right-transform">
-    <ul class="learn-menu-content">
-      {{ $currentPage := . }}
-      {{ range $index, $element:=.Site.Menus.learn }} {{ if .HasChildren }}
-      <li class='learn-menu-item'>
-        <div class='learn-menu-title{{ if $currentPage.HasMenuCurrent "learn" . }} active{{ end }}' id="{{$index}}">
-          <img src="{{.Pre}}" width="24" height="24" alt="{{.Name}}" />
-          {{.Name}}
-        </div>
-        <ul class='learn-menu-sub {{ if $currentPage.HasMenuCurrent "learn" . }}menu-display{{ end }}' id="learn-menu-{{$index}}">
-          {{range .Children}} {{ $has := $currentPage.IsMenuCurrent "learn" . }}
-          <li class="learn-menu-sub-item {{if $has}}active{{end}}">
-            <a href="{{.URL}}">
-              {{ partial "docs-title" . }}
-            </a>
-          </li>
-          {{end}}
-        </ul>
-      </li>
-      {{else}}
-      <li class="learn-menu-item" id="learn-menu-{{$index}}">
-        <div class="learn-menu-title">{{.Name}}</div>
-      </li>
-      {{end}} {{end}}
-    </ul>
-  </nav>
-  <div class="learn-menu-mobile-right-space">
-  </div>
+{{- $url := replace .Permalink ( printf "%s" .Site.BaseURL) "/" -}}
+{{- $paths := split $url "/" -}}
+{{- $learnSection := (index $paths 2) -}}
 
-  <!-- Restore menu position as soon as possible to avoid flickering -->
-  <script>
-    (function () {
-      var menu = document.querySelector('aside.learn-menu nav')
-      addEventListener('beforeunload', function () {
-        localStorage.setItem('menu.scrollTop', menu.scrollTop)
-      })
-      menu.scrollTop = localStorage.getItem('menu.scrollTop')
-    })()
-  </script>
-
-</aside>
-
+{{- if eq $learnSection "playwright" -}}
+  {{ partial "learn-playwright-menu" . }}
+{{- else -}}
+  {{ partial "learn-menu-generic" (dict "learnSection" $learnSection "page" .) }}
+{{- end -}}

--- a/site/layouts/partials/learn-playwright-menu.html
+++ b/site/layouts/partials/learn-playwright-menu.html
@@ -1,0 +1,46 @@
+<aside class="learn-menu">
+  <nav id="sideMenu" class="left-transform right-transform">
+    <ul class="learn-menu-content">
+      {{- $currentPage := . -}}
+      {{- $entries := .Site.Menus.learn_playwright -}}
+      {{- $menuID := "learn_playwright" -}}
+
+      {{- range $index, $element:= $entries -}}  {{- if .HasChildren -}}
+      <li class='learn-menu-item'>
+        <div class='learn-menu-title{{ if $currentPage.HasMenuCurrent $menuID . }} active{{ end }}' id="{{$index}}">
+          <img src="{{.Pre}}" width="24" height="24" alt="{{.Name}}" />
+          {{.Name}}
+        </div>
+        <ul class='learn-menu-sub {{ if $currentPage.HasMenuCurrent $menuID . }}menu-display{{ end }}' id="learn-menu-{{$index}}">
+          {{range .Children}} {{ $has := $currentPage.IsMenuCurrent $menuID . }}
+          <li class="learn-menu-sub-item {{if $has}}active{{end}}">
+            <a href="{{.URL}}">
+              {{ partial "docs-title" . }}
+            </a>
+          </li>
+          {{end}}
+        </ul>
+      </li>
+      {{else}}
+      <li class="learn-menu-item" id="learn-menu-{{$index}}">
+        <div class="learn-menu-title">{{.Name}}</div>
+      </li>
+      {{end}} {{end}}
+    </ul>
+  </nav>
+  <div class="learn-menu-mobile-right-space">
+  </div>
+
+  <!-- Restore menu position as soon as possible to avoid flickering -->
+  <script>
+    (function () {
+      var menu = document.querySelector('aside.learn-menu nav')
+      addEventListener('beforeunload', function () {
+        localStorage.setItem('menu.scrollTop', menu.scrollTop)
+      })
+      menu.scrollTop = localStorage.getItem('menu.scrollTop')
+    })()
+  </script>
+
+</aside>
+

--- a/site/layouts/partials/learn-title.html
+++ b/site/layouts/partials/learn-title.html
@@ -1,0 +1,15 @@
+{{ $title := "" }}
+{{ if .Page.Params.navTitle}}
+  {{ $title = .Page.Params.navTitle}}
+{{ else if .Page.Params.displayTitle}}
+  {{ $title = .Page.Params.displayTitle}}
+{{ else if .Title }}
+  {{ $title = .Title }}
+{{ else if and .IsSection .File }}
+  {{ $sections := split (trim .File.Dir "/") "/" }}
+  {{ $title = index ($sections | last 1) 0 | humanize | title }}
+{{ else if and .IsPage .File }}
+  {{ $title = .File.BaseFileName | humanize | title }}
+{{ end }}
+
+{{ return $title }}


### PR DESCRIPTION
…ic menu structure. adds index pages for pwt and k8s sections [sc-00]

## Affected Components
* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [x] Docs
* [x] Learn
* [ ] Other

## Pre-Requisites
* [ ] Code is linted (`npm run lint`)

## Notes for the Reviewer
- adds each learn section (pwt, otel and k8s) to its own menu ID, e.g. `learn_playwright` and `learn_opentelemetry`
- adds a global index page for "learn".
- adds dedicated index pages for each section.
- introduces new partials for rendering the menus. New menus for new section are now simpler to create.

The URL structure has not changed.

Note: we need to make the copy and style of the new index pages maybe a bit better. It's bare bones now.

## Screenshots

See the preview deployment.
