### PR TITLE
fix: redirect all docs. traffic to /docs

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -34,14 +34,15 @@
   ],
   "redirects": [
     {
-      "source": "/",
+      "source": "/:path*",
       "has": [
         {
           "type": "host",
           "value": "docs.checklyhq.com"
         }
       ],
-      "destination": "https://www.checklyhq.com/docs/"
+      "destination": "https://www.checklyhq.com/docs/:path*",
+      "permanent": true
     },
     { "source": "/learn/headless/avoiding-hard-waits(/)?", "destination": "/learn/playwright/waits-and-timeouts", "permanent": true },
     { "source": "/learn/headless/basics-clicking-typing(/)?", "destination": "/learn/playwright/clicking-typing-hovering", "permanent": true },


### PR DESCRIPTION
## Affected Components
* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [ ] Docs
* [ ] Learn
* [x] Other

## Pre-Requisites
* [ ] Code is linted (`npm run lint`)

## Notes for the Reviewer
Only the root was redirected, not nested pages.
