### PR TITLE
feat: set toc level to h2 for learn and guides

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -218,4 +218,9 @@ disqusShortname = "checkly"
 
 
 [markup.goldmark.renderer]
-unsafe = true
+	unsafe = true
+
+[markup.tableOfContents]
+	startLevel = 2
+	endLevel = 3
+

--- a/src/scss/_guides.scss
+++ b/src/scss/_guides.scss
@@ -243,6 +243,10 @@
     }
 
     nav#TableOfContents {
+		// hacky way to hide 3rd level heading in little page TOC because Hugo does not allow filtering the TOC by level
+		ul ul {
+			display: none;
+		}
       ul {
         border-left: 2px solid $blue;
         padding-left: .5rem;

--- a/src/scss/_learn.scss
+++ b/src/scss/_learn.scss
@@ -268,9 +268,13 @@
       overflow-x: hidden;
       overflow-y: auto
     }
-    // hacky way to hide 3rd level heading in little page TOC because Hugo does not allow filtering the TOC by level
 
     nav#TableOfContents {
+      // hacky way to hide 3rd level heading in little page TOC because Hugo does not allow filtering the TOC by level
+      ul ul {
+        display: none;
+      }
+
       ul {
         border-left: 2px solid $red;
         padding-left: .5rem;


### PR DESCRIPTION
## Affected Components
* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [ ] Docs
* [x] Learn
* [ ] Other

## Pre-Requisites
* [ ] Code is linted (`npm run lint`)


## Notes for the Reviewer
hides h3 links in TOC for /learn and /guides
