### PR TITLE
fix: update start url for learn

### DIFF
--- a/algolia/config-docs.json
+++ b/algolia/config-docs.json
@@ -1,7 +1,7 @@
 {
   "index_name": "checkly_docs",
   "start_urls": ["https://www.checklyhq.com/docs"],
-  "sitemap_urls": ["https://docs.checklyhq.com/sitemap.xml"],
+  "sitemap_urls": ["https://www.checklyhq.com/docs-sitemap.xml"],
   "selectors": {
     "lvl0": {
       "selector": ".DocSearch-lvl1",

--- a/algolia/config-learn.json
+++ b/algolia/config-learn.json
@@ -1,13 +1,18 @@
 {
-  "index_name": "checkly_docs_learning",
+  "index_name": "checkly_learn",
   "start_urls": ["https://www.checklyhq.com/learn/"],
   "stop_urls": [
     ".*(?<!/)$"
   ],
   "selectors": {
-    "lvl0": ".learn-page article h1",
-    "lvl1": ".learn-page article h2",
-    "lvl2": ".learn-page article h3",
-    "text": ".learn-page article p,.learn-page article ul,.learn-page article ol"
+    "lvl0": {
+      "selector": ".DocSearch-lvl1",
+      "global": true,
+      "default_value": "Learn"
+    },
+    "lvl1": ".learn-page article h1",
+    "lvl2": ".learn-page article h2",
+    "lvl3": ".learn-page article h3",
+    "text": ".DocSearch-content p, .DocSearch-content li, .DocSearch-content .alert"
   }
 }

--- a/algolia/config-learn.json
+++ b/algolia/config-learn.json
@@ -1,6 +1,6 @@
 {
   "index_name": "checkly_docs_learning",
-  "start_urls": ["https://www.checklyhq.com/learn/headless"],
+  "start_urls": ["https://www.checklyhq.com/learn/"],
   "stop_urls": [
     ".*(?<!/)$"
   ],

--- a/site/layouts/learn/single.html
+++ b/site/layouts/learn/single.html
@@ -2,7 +2,7 @@
   <div class="d-flex container-fluid learn">
     {{- partial "learn-menu" . -}}
     <div class="learn-page">
-      <article class="markdown">
+      <article class="markdown DocSearch-content">
 
         {{ partial "learn-breadcrumb" .}}
 

--- a/site/layouts/partials/learn-breadcrumb.html
+++ b/site/layouts/partials/learn-breadcrumb.html
@@ -10,16 +10,16 @@
       {{ if ne $element "learn" }}
         {{ if eq $index 2 }}
             {{ if eq $element "playwright" }}
-              <a href="/learn/playwright/">Playwright Automation Guide</a>
+              <a href="/learn/playwright/" class="DocSearch-lvl1">Playwright Automation Guide</a>
             {{ end }}
             {{ if eq $element "opentelemetry" }}
-              <a href="/learn/opentelemetry/">Open Telemetry Guide</a>
+              <a href="/learn/opentelemetry/" class="DocSearch-lvl1">Open Telemetry Guide</a>
             {{ end }}
             {{ if eq $element "kubernetes" }}
-            <a href="/learn/kubernetes/">Kubernetes Monitoring Guide</a>
+            <a href="/learn/kubernetes/" class="DocSearch-lvl1">Kubernetes Monitoring Guide</a>
             {{ end }}
             {{ if eq $element "monitoring" }}
-            <a href="/learn/monitoring/">Monitoring Guide</a>
+            <a href="/learn/monitoring/" class="DocSearch-lvl1">Monitoring Guide</a>
           {{ end }}
         {{ else }}
           <span>/</span>

--- a/src/js/learn.js
+++ b/src/js/learn.js
@@ -142,6 +142,5 @@ window.docsearch({
   apiKey: 'b2b616fdea14b860ff00c72fa72bf267',
   indexName: 'checkly_learn',
   appId: 'LCMJSZN73Z',
-  container: '#docsearch',
-  debug: true
+  container: '#docsearch'
 })


### PR DESCRIPTION
## Affected Components
* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [ ] Docs
* [x] Learn
* [x] Other

## Pre-Requisites
* [ ] Code is linted (`npm run lint`)

## Notes for the Reviewer
updates algolia config to reflect new situation
