### PR TITLE
chore: remove tnolet as default. alert on hugo versions.

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,9 +1,6 @@
 addReviewers: true
 addAssignees: author
 
-reviewers:
-  - tnolet
-
 skipKeywords:
   - wip
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,6 +35,4 @@ updates:
     - dependency-name: debug
       versions:
       - 2.6.9
-    - dependency-name: hugo
-    - dependency-name: hugo-bin
 


### PR DESCRIPTION
## Affected Components
* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [ ] Docs
* [ ] Learn
* [x] Other

## Pre-Requisites
* [ ] Code is linted (`npm run lint`)


## Notes for the Reviewer
- don't assign tnolet as default reviewer
- let dependabot alert on `hugo` versions