### PR TITLE
fix: axios import statement in API setup script example

### DIFF
--- a/site/content/docs/api-checks/setup-script-examples.md
+++ b/site/content/docs/api-checks/setup-script-examples.md
@@ -19,7 +19,7 @@ Here are some examples on how to address common authentication use cases with se
 {{< tabs "fetch token" >}}
 {{< tab "TypeScript" >}}
 ```ts
-import { axios } from 'axios'
+import axios from 'axios'
 
 // use 'await' on an axios HTTP get to fetch a token from a location
 const { data } = await axios.get('https://example.com/api/token')


### PR DESCRIPTION
## Affected Components
* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [x] Docs
* [ ] Learn
* [ ] Other

## Pre-Requisites
* [x] Code is linted (`npm run lint`)

## Notes for the Reviewer
Super tiny change. `import { axios } from 'axios'` doesn't work, so I changed it to the working `import axios from 'axios'`.

Axios uses the default import in their documentation (for example, [in this code snippet](https://www.npmjs.com/package/axios/v/0.27.2#form-data)).

I also verified this by creating two checks. They're identical except for the axios import statement in the setup script.
* You can view them in my account (`1631b1ea-30aa-432f-bb37-cf96f43a1480`)
* I'm on the latest runtime 2024.09
* [axios as named import](https://app.checklyhq.com/checks/094a4014-d448-4809-9ac8-f59204f8d5f4) (failing with `There was an error in your setup script: TypeError: Cannot read properties of undefined (reading 'get')`)
* [axios as default import](https://app.checklyhq.com/checks/d8c98934-2bdd-467b-93fb-9c2f16999429) (passing) 