### PR TITLE
Tnolet/fix nav structure list pages

### DIFF
--- a/site/content/docs/api-checks/client-certificates.md
+++ b/site/content/docs/api-checks/client-certificates.md
@@ -2,7 +2,7 @@
 title: Client certificates - Checkly Docs
 displayTitle: Client certificates
 navTitle: Client certificates
-weight: 14
+weight: 17
 menu:
   resources:
     parent: "API checks"

--- a/site/content/docs/api-checks/setup-script-examples.md
+++ b/site/content/docs/api-checks/setup-script-examples.md
@@ -2,7 +2,7 @@
 title: API setup script examples - Checkly Docs
 displayTitle: API setup script examples
 navTitle: Setup script examples
-weight: 1
+weight: 13
 menu:
   resources:
     parent: "API setup & teardown scripts - Checkly Docs"

--- a/site/content/docs/api-checks/teardown-script-examples.md
+++ b/site/content/docs/api-checks/teardown-script-examples.md
@@ -2,7 +2,7 @@
 title: API teardown script examples - Checkly Docs
 displayTitle: API teardown script examples
 navTitle: Teardown script examples
-weight: 2
+weight: 14
 menu:
   resources:
     parent: "API setup & teardown scripts - Checkly Docs"

--- a/site/content/docs/api-checks/timeouts-timing.md
+++ b/site/content/docs/api-checks/timeouts-timing.md
@@ -2,7 +2,7 @@
 title: API timeouts and timing phases - Checkly Docs
 displayTitle: API timeouts and timing phases
 navTitle: Timeouts and timing phases
-weight: 13
+weight: 16
 menu:
   resources:
     parent: "API checks"

--- a/site/layouts/docs/list.html
+++ b/site/layouts/docs/list.html
@@ -47,16 +47,7 @@
         </p>
     </article>
   </div>
-  <aside class="docs-toc mb-3">
-    <div id="tocMenu">
-      <div class="docs-toc-on-this-page">
-        <div class="docs-toc-header">On this page</div>
-        {{ .Page.TableOfContents }}
-      </div>
-      {{ partial "toc-sidebar-community" .}}
-      {{ partial "toc-sidebar-support" .}}
-    </div>
-  </aside>
+  {{- partial "toc-sidebar" . -}}
 </div>
 {{- partial "structured-data-article" . -}}
 {{end}}

--- a/site/layouts/docs/single.html
+++ b/site/layouts/docs/single.html
@@ -76,16 +76,7 @@
         </p>
       </article>
     </div>
-    <aside class="docs-toc mb-3">
-      <div id="tocMenu">
-        <div class="docs-toc-on-this-page">
-          <div class="docs-toc-header">On this page</div>
-          {{ .Page.TableOfContents }}
-        </div>
-        {{ partial "toc-sidebar-community" .}}
-        {{ partial "toc-sidebar-support" .}}
-      </div>
-    </aside>
+    {{- partial "toc-sidebar" . -}}
   </div>
   {{- partial "structured-data-article" . -}}
 {{end}}

--- a/site/layouts/learn/single.html
+++ b/site/layouts/learn/single.html
@@ -19,32 +19,54 @@
         {{- .Content -}}
       </article>
       {{if and (.NextInSection) (.PrevInSection)}}
-      <div class="d-flex justify-content-between flex-wrap next-nav my-5">
-        <a href="{{.NextInSection.Permalink}}" class="nav-docs">
-          <svg class="mr-2" width="11" height="11" viewBox="0 0 11 11" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path class="learn" fill-rule="evenodd" clip-rule="evenodd" d="M5.78033 10.5303C5.48744 10.8232 5.01256 10.8232 4.71967 10.5303L0.469668 6.28033C0.176777 5.98744 0.176777 5.51256 0.469668 5.21967L4.71967 0.969668C5.01256 0.676777 5.48744 0.676777 5.78033 0.969668C6.07322 1.26256 6.07322 1.73744 5.78033 2.03033L2.81066 5H10.25C10.6642 5 11 5.33579 11 5.75C11 6.16421 10.6642 6.5 10.25 6.5H2.81066L5.78033 9.4697C6.07322 9.7626 6.07322 10.2374 5.78033 10.5303Z" fill="#0075ff"/>
-            </svg>{{ .NextInSection.Title }}</a>
-        <a href="{{.PrevInSection.Permalink}}" class="nav-docs">{{ .PrevInSection.Title }}
+        <div class="d-flex justify-content-between flex-wrap next-nav my-5">
+          <a href="{{.NextInSection.RelPermalink}}" class="nav-docs">
+            <svg class="mr-2" width="11" height="11" viewBox="0 0 11 11" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path class="learn" fill-rule="evenodd" clip-rule="evenodd" d="M5.78033 10.5303C5.48744 10.8232 5.01256 10.8232 4.71967 10.5303L0.469668 6.28033C0.176777 5.98744 0.176777 5.51256 0.469668 5.21967L4.71967 0.969668C5.01256 0.676777 5.48744 0.676777 5.78033 0.969668C6.07322 1.26256 6.07322 1.73744 5.78033 2.03033L2.81066 5H10.25C10.6642 5 11 5.33579 11 5.75C11 6.16421 10.6642 6.5 10.25 6.5H2.81066L5.78033 9.4697C6.07322 9.7626 6.07322 10.2374 5.78033 10.5303Z" fill="#0075ff"/>
+              </svg>
+              {{ if .NextInSection.Params.navTitle }}
+                {{ .NextInSection.Params.navTitle }}
+              {{ else }}
+                {{ .NextInSection.Title }}
+              {{ end }}
+          </a>
+          <a href="{{.PrevInSection.RelPermalink}}" class="nav-docs">
+            {{ if .PrevInSection.Params.navTitle }}
+              {{ .PrevInSection.Params.navTitle }}
+            {{ else }}
+              {{ .PrevInSection.Title }}
+            {{ end }}
+            <svg class="ml-2" width="11" height="11" viewBox="0 0 11 11" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path class="learn" fill-rule="evenodd" clip-rule="evenodd" d="M5.21967 0.969668C5.51256 0.676777 5.98744 0.676777 6.28033 0.969668L10.5303 5.21967C10.8232 5.51256 10.8232 5.98744 10.5303 6.28033L6.28033 10.5303C5.98744 10.8232 5.51256 10.8232 5.21967 10.5303C4.92678 10.2374 4.92678 9.7626 5.21967 9.4697L8.1893 6.5H0.75C0.33579 6.5 0 6.16421 0 5.75C0 5.33579 0.33579 5 0.75 5H8.1893L5.21967 2.03033C4.92678 1.73744 4.92678 1.26256 5.21967 0.969668Z" fill="#0075ff"/>
+              </svg>
+              </a>
+        </div>
+      {{ else if .PrevInSection }}
+        <div class="text-right next-nav my-5">
+        <a href="{{.PrevInSection.RelPermalink}}">
+            {{ if .PrevInSection.Params.navTitle }}
+              {{ .PrevInSection.Params.navTitle }}
+            {{ else }}
+              {{ .PrevInSection.Title }}
+            {{ end }}
           <svg class="ml-2" width="11" height="11" viewBox="0 0 11 11" fill="none" xmlns="http://www.w3.org/2000/svg">
             <path class="learn" fill-rule="evenodd" clip-rule="evenodd" d="M5.21967 0.969668C5.51256 0.676777 5.98744 0.676777 6.28033 0.969668L10.5303 5.21967C10.8232 5.51256 10.8232 5.98744 10.5303 6.28033L6.28033 10.5303C5.98744 10.8232 5.51256 10.8232 5.21967 10.5303C4.92678 10.2374 4.92678 9.7626 5.21967 9.4697L8.1893 6.5H0.75C0.33579 6.5 0 6.16421 0 5.75C0 5.33579 0.33579 5 0.75 5H8.1893L5.21967 2.03033C4.92678 1.73744 4.92678 1.26256 5.21967 0.969668Z" fill="#0075ff"/>
             </svg>
-            </a>
-      </div>
-      {{ else if .PrevInSection }}
-      <div class="text-right next-nav my-5">
-      <a href="{{.PrevInSection.Permalink}}">{{ .PrevInSection.Title }}
-        <svg class="ml-2" width="11" height="11" viewBox="0 0 11 11" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path class="learn" fill-rule="evenodd" clip-rule="evenodd" d="M5.21967 0.969668C5.51256 0.676777 5.98744 0.676777 6.28033 0.969668L10.5303 5.21967C10.8232 5.51256 10.8232 5.98744 10.5303 6.28033L6.28033 10.5303C5.98744 10.8232 5.51256 10.8232 5.21967 10.5303C4.92678 10.2374 4.92678 9.7626 5.21967 9.4697L8.1893 6.5H0.75C0.33579 6.5 0 6.16421 0 5.75C0 5.33579 0.33579 5 0.75 5H8.1893L5.21967 2.03033C4.92678 1.73744 4.92678 1.26256 5.21967 0.969668Z" fill="#0075ff"/>
-          </svg>
-      </a>
-      </div>
+        </a>
+        </div>
       {{ else if .NextInSection}}
-      <div class="text-left next-nav my-5">
-      <a href="{{.NextInSection.Permalink}}" class="nav-docs">
-        <svg class="mr-2" width="11" height="11" viewBox="0 0 11 11" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path class="learn" fill-rule="evenodd" clip-rule="evenodd" d="M5.78033 10.5303C5.48744 10.8232 5.01256 10.8232 4.71967 10.5303L0.469668 6.28033C0.176777 5.98744 0.176777 5.51256 0.469668 5.21967L4.71967 0.969668C5.01256 0.676777 5.48744 0.676777 5.78033 0.969668C6.07322 1.26256 6.07322 1.73744 5.78033 2.03033L2.81066 5H10.25C10.6642 5 11 5.33579 11 5.75C11 6.16421 10.6642 6.5 10.25 6.5H2.81066L5.78033 9.4697C6.07322 9.7626 6.07322 10.2374 5.78033 10.5303Z" fill="#0075ff"/>
-        </svg>{{ .NextInSection.Title }}</a>
-      </div>
+        <div class="text-left next-nav my-5">
+        <a href="{{.NextInSection.RelPermalink}}" class="nav-docs">
+          <svg class="mr-2" width="11" height="11" viewBox="0 0 11 11" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path class="learn" fill-rule="evenodd" clip-rule="evenodd" d="M5.78033 10.5303C5.48744 10.8232 5.01256 10.8232 4.71967 10.5303L0.469668 6.28033C0.176777 5.98744 0.176777 5.51256 0.469668 5.21967L4.71967 0.969668C5.01256 0.676777 5.48744 0.676777 5.78033 0.969668C6.07322 1.26256 6.07322 1.73744 5.78033 2.03033L2.81066 5H10.25C10.6642 5 11 5.33579 11 5.75C11 6.16421 10.6642 6.5 10.25 6.5H2.81066L5.78033 9.4697C6.07322 9.7626 6.07322 10.2374 5.78033 10.5303Z" fill="#0075ff"/>
+          </svg>
+          {{ if .NextInSection.Params.navTitle }}
+            {{ .NextInSection.Params.navTitle }}
+          {{ else }}
+            {{ .NextInSection.Title }}
+          {{ end }}
+        </a>
+        </div>
       {{end}}
       <hr class="pt-2 mb-2" />
       <p class="contribute-doc">

--- a/site/layouts/partials/toc-sidebar.html
+++ b/site/layouts/partials/toc-sidebar.html
@@ -1,1 +1,10 @@
-<div class="toc-sidebar"><p class="toc-sidebar-header">On this page</p><span>{{.TableOfContents}}</span></div>
+<aside class="docs-toc mb-3">
+    <div id="tocMenu" class="docs-toc-content">
+        <div class="docs-toc-on-this-page">
+            <div class="docs-toc-header">On this page</div>
+            {{ .Page.TableOfContents }}
+        </div>
+        {{ partial "toc-sidebar-community" .}}
+        {{ partial "toc-sidebar-support" .}}
+    </div>
+</aside>

--- a/src/js/docs.js
+++ b/src/js/docs.js
@@ -24,11 +24,7 @@ $(document).ready(() => {
  */
 
 $(document).ready(() => {
-  if ($('#TableOfContents ul').length >= 1) {
-    $('.docs-toc-on-this-page').css({
-      display: 'block'
-    })
-  } else {
+  if ($('#TableOfContents ul').length === 0) {
     $('.docs-toc-on-this-page').css({
       display: 'none'
     })
@@ -98,15 +94,14 @@ $(window).on('scroll', function () {
     })
     $('#tocMenu').css({
       position: 'fixed',
-      top: '30px'
+      top: '0px'
     })
   } else {
     $('#sideMenu').css({
       position: 'relative'
     })
     $('#tocMenu').css({
-      position: 'relative',
-      top: '0'
+      position: 'relative'
     })
   }
 })

--- a/src/scss/_docs.scss
+++ b/src/scss/_docs.scss
@@ -249,18 +249,30 @@
   }
 
   &-toc {
-    position: relative;
+    display: flex;
+    flex-direction: column;
     flex: 0 0 $toc-width;
     font-size: .875rem;
     margin-right: auto;
     width: 232px;
-    padding-top: 1rem;
+
+    &-content {
+      padding: 1rem 0 1rem 1rem;
+      height: calc(100vh - 1rem);
+      overflow-x: hidden;
+      overflow-y: auto;
+      scrollbar-width: thin;
+    }
 
     nav {
       width: $toc-width;
       bottom: 0;
       overflow-x: hidden;
-      overflow-y: auto
+      overflow-y: auto;
+      ul ul {
+        padding-left: 1rem;
+        border-left: none !important;
+      }
     }
     // hacky way to hide 3rd level heading in little page TOC because Hugo does not allow filtering the TOC by level
 
@@ -280,11 +292,6 @@
           }
         }
       }
-    }
-
-    nav ul ul {
-      padding-left: 1rem;
-      border-left: none !important;
     }
 
     &-header {


### PR DESCRIPTION
## Affected Components
* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [x] Docs
* [x] Learn
* [ ] Other

## Pre-Requisites
* [ ] Code is linted (`npm run lint`)

## Notes for the Reviewer
Bundle of fixes:
- TOC sidebar in /docs now scrolls when it gets long
- next/prev links in /learn no use proper links
- order API docs so next/prev makes senses