### PR TITLE
docs: Prometheus V2 - update cache documentation

### DIFF
--- a/site/content/docs/integrations/prometheus-v2.md
+++ b/site/content/docs/integrations/prometheus-v2.md
@@ -43,8 +43,8 @@ Now restart Prometheus and you should see metrics coming in.
 
 >[!WARNING]
 > The Prometheus metrics endpoint has a rate limit of 50 requests per minute.
-> The responses from this endpoint are cached during 60 seconds.
-> Any request made to this endpoint within 60 seconds of the initial request will receive the cached response.
+> The responses from this endpoint are cached during 50 seconds.
+> Any request made to this endpoint within 50 seconds of the initial request will receive the cached response.
 > We recommend using a scrape interval of 60 seconds.
 
 ## Check Metrics


### PR DESCRIPTION
## Affected Components
* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [x] Docs
* [ ] Learn
* [ ] Other

## Pre-Requisites
* [ ] Code is linted (`npm run lint`)

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
See https://github.com/checkly/checkly-backend/pull/6227

Prometheus V2 metrics will be cached for 50 seconds.
