### PR TITLE
Add new PWN docs section for custom dependencies

### DIFF
--- a/site/content/docs/playwright-checks/custom-dependencies.md
+++ b/site/content/docs/playwright-checks/custom-dependencies.md
@@ -47,7 +47,6 @@ There are no dependency changes required if you rely on private packages or a cu
 }
 ```
 
-However, relying on private dependencies needs additional configuration.
 
 Regardless of whether you use private packages or a custom registry, the Checkly infrastructure needs to authenticate with your provider to `install` your private source code.
 

--- a/site/content/docs/playwright-checks/custom-dependencies.md
+++ b/site/content/docs/playwright-checks/custom-dependencies.md
@@ -13,7 +13,7 @@ Playwright Check Suites let you take your existing Playwright tests and turn the
 
 ## Using JavaScript/Node.js dependencies
 
-Whether you use [npm](https://www.npmjs.com/), [yarn](https://yarnpkg.com/), or [pnpm](https://pnpm.io/); Checkly reuses your existing `package.json` and lock files to install the correct `devDependencies` and prepare your testing and monitoring environment.
+Whether you use [npm](https://www.npmjs.com/), [yarn](https://yarnpkg.com/), or [pnpm](https://pnpm.io/); Checkly uses your existing `package.json` and lock files to install the correct `devDependencies` and prepare your testing and monitoring environment.
 
 ```json {title="package.json"}
 {

--- a/site/content/docs/playwright-checks/custom-dependencies.md
+++ b/site/content/docs/playwright-checks/custom-dependencies.md
@@ -1,0 +1,108 @@
+---
+title: Custom dependencies in Playwright Check Suites
+displayTitle: Using custom dependencies in Playwright Check Suites
+navTitle: Custom dependencies
+weight: 16
+slug: /custom-dependencies
+menu:
+  resources:
+    parent: "Playwright Check Suites (Alpha)"
+---
+
+Playwright Check Suites let you take your existing Playwright tests and turn them into globally distributed monitoring. The Checkly CLI requires no Playwright configuration changes and will parse your existing settings and dependencies to prepare the Checkly monitoring infrastructure.
+
+## Using JavaScript/Node.js dependencies
+
+Whether you use [npm](https://www.npmjs.com/), [yarn](https://yarnpkg.com/), or [pnpm](https://pnpm.io/); Checkly reuses your existing `package.json` and lock files to install the correct `devDependencies` and prepare your testing and monitoring environment.
+
+```json {title="package.json"}
+{
+  "devDependencies": {
+    "@faker-js/faker": "^9.7.0"
+  }
+}
+```
+
+**By default, the Checkly infrastructure installs dependencies via npm.**
+
+However, if an alternative lock file (`pnpm-lock.json` or `yarn.lock`) is discovered, Checkly uses the matching package manager to install the project dependencies.
+
+| Available lock file | Package manager |
+|---------------------|-----------------|
+| `package-lock.json` | npm             |
+| `pnpm-lock.json`    | pnpm            |
+| `yarn.lock`         | yarn            |
+
+> **For `pnpm` users:** if you define the same dependency in `dependencies` and `devDependencies`, please use a custom `installCommand` in your `checkly.config.ts|js` to register your package as a development dependency: `pnpm install --dev additional-package`
+
+## Using private dependencies
+
+There are no dependency changes required if you rely on private packages or a custom package registry. The Checkly CLI detects existing private `package.json` dependencies just fine.
+
+```json {title="package.json"}
+{
+  "devDependencies": {
+    "@your-org/private-package": "^2.3.0"
+  }
+}
+```
+
+However, relying on private dependencies needs additional configuration.
+
+Regardless of whether you use private packages or a custom registry, the Checkly infrastructure needs to authenticate with your provider to `install` your private source code.
+
+For example, if you use npm to manage your private dependencies, you need to:
+
+- **add custom npm configuration** to your project.
+- **include custom configuration files** in your Checkly project to make the infrastructure aware.
+
+### Custom npm configuration for private packages
+
+Let's look at popular options for private packages:
+
+- using private npm packages on the public npm registry.
+- using npm with JFrog Artifactory.
+
+To access the private source code, npm relies on custom configuration in a project-specific `.npmrc` file.
+
+> To avoid putting sensitive information into your `.npmrc` we recommend setting your authentication token via Checkly environment variables [available in the UI](https://app.checklyhq.com/environment-variables) or [the CLI](https://www.checklyhq.com/docs/cli/using-environment-variables/#managing-remote-environment-variables-using-the-cli).
+
+#### Using private npm packages
+
+```txt {title=".npmrc"}
+# Hard-coded authentication token
+//registry.npmjs.org/:_authToken=npm_abc...
+
+# Authentication token defined in environment variables
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}
+```
+
+#### Using JFrog Artifactory
+
+```txt {title=".npmrc"}
+# Custom registry URL with hard-coded authentication token
+registry=https://yourcompany.jfrog.io/artifactory/api/npm/yourcompany.jfrog.io/artifactory/api/npm/npm-local/:_authToken=abc...
+
+# Custom registry URL with authentication token defined in environment variables
+registry=https://yourcompany.jfrog.io/artifactory/api/npm/yourcompany.jfrog.io/artifactory/api/npm/npm-local/:_authToken=${ARTIFACTORY_TOKEN}
+```
+
+### Include custom configuration files
+
+To make the Checkly CLI and infrastructure aware of a custom package manager configuration for private packages, specify the additional files in the `checks.include` property in your `checkly.config.ts|js`.
+
+Checkly CLI commands like `test` or `deploy` will then bundle and upload these files so they are available in the Checkly infrastructure when running essential commands like `install`.
+
+```tsx {title="checkly.config.ts"}
+export default defineConfig({
+  checks: {
+    playwrightConfigPath: './playwright.config.ts',
+    // Include .npmrc to be used in the Checkly infrastructure
+    include: ['.npmrc'],
+    playwrightChecks: [
+      // Configure your Playwright Check Suites
+      // ...
+    ]
+  }
+})
+```

--- a/site/content/docs/playwright-checks/custom-dependencies.md
+++ b/site/content/docs/playwright-checks/custom-dependencies.md
@@ -37,7 +37,7 @@ However, if an alternative lock file (`pnpm-lock.json` or `yarn.lock`) is discov
 
 ## Using private dependencies
 
-There are no dependency changes required if you rely on private packages or a custom package registry. The Checkly CLI detects existing private `package.json` dependencies just fine.
+There are no dependency changes required if you rely on private packages or a custom package registry. The Checkly CLI detects your existing private `package.json` dependencies and installs those using the credentials provided.
 
 ```json {title="package.json"}
 {

--- a/site/content/docs/playwright-checks/custom-dependencies.md
+++ b/site/content/docs/playwright-checks/custom-dependencies.md
@@ -9,7 +9,7 @@ menu:
     parent: "Playwright Check Suites (Alpha)"
 ---
 
-Playwright Check Suites let you take your existing Playwright tests and turn them into globally distributed monitoring. The Checkly CLI requires no Playwright configuration changes and will parse your existing settings and dependencies to prepare the Checkly monitoring infrastructure.
+Playwright Check Suites let you take your existing Playwright tests and turn them into globally distributed monitoring using the [Checkly CLI](/docs/cli/). It will read your Playwright configuration and parse your existing settings and dependencies to prepare the Checkly monitoring infrastructure.
 
 ## Using JavaScript/Node.js dependencies
 

--- a/site/content/docs/private-locations/_index.md
+++ b/site/content/docs/private-locations/_index.md
@@ -92,6 +92,8 @@ While a location is unavailable, no checks will be scheduled to run on it. When 
 
 ## Using Playwright Check Suites in private locations
 
-We recommend to update the Checkly agent regularly. However, [Playwright Check Suites](/docs/playwright-checks/) are available in private locations since Checkly Agent `6.0.3`.
+We recommend to update the Checkly agent regularly. 
+
+* [Playwright Check Suites](/docs/playwright-checks/) are available in private locations since Checkly Agent `6.0.3`.
 
 Please use a minimum container size of 2 CPU cores and 4 GB of RAM when running Playwright Check Suites.

--- a/site/content/docs/private-locations/_index.md
+++ b/site/content/docs/private-locations/_index.md
@@ -89,3 +89,9 @@ new ApiCheck('hello-api-1', {
 If a private location has had no Checkly agents connected for more than 10 minutes, it will be flagged as unavailable. Checkly will email account owners and admins that the location has become unavailable.
 
 While a location is unavailable, no checks will be scheduled to run on it. When a location becomes available, check scheduling and execution will resume automatically.
+
+## Using Playwright Check Suites in private locations
+
+We recommend to update the Checkly agent regularly. However, [Playwright Check Suites](/docs/playwright-checks/) are available in private locations since Checkly Agent `6.0.3`.
+
+Please use a minimum container size of 2 CPU cores and 4 GB of RAM when running Playwright Check Suites.


### PR DESCRIPTION
## Affected Components
* [ ] Content & Marketing
* [ ] Pricing
* [ ] Test
* [x] Docs
* [ ] Learn
* [ ] Other

## Notes for the Reviewer

After request from @MariadeAnton, I took an existing draft and turned it into a docs page.

Draft: https://www.notion.so/checkly/Public-page-Private-Locations-and-Custom-dependencies-in-Playwright-Check-Suites-200ec050b06e80ab81cacdc0ec8d23ec